### PR TITLE
dev_ExactSumEnergyEvaluatorMPI

### DIFF
--- a/examples/vmc_executor_exact_summation_example.cpp
+++ b/examples/vmc_executor_exact_summation_example.cpp
@@ -105,8 +105,8 @@ void DemonstrateVMCExecutorExactSummation() {
     
     // 🔧 EXACT SUMMATION INTEGRATION: Replace Monte Carlo with exact computation (unified interface)
     auto exact_energy_evaluator = [&](const SITPST &state) -> std::tuple<TenElemT, SITPST, double> {
-        auto [energy, gradient, error] = ExactSumEnergyEvaluator(
-            state, all_configs, trun_para, heisenberg_model, Ly, Lx);
+        auto [energy, gradient, error] = ExactSumEnergyEvaluatorMPI(
+            state, all_configs, trun_para, heisenberg_model, Ly, Lx, MPI_COMM_WORLD, qlten::hp_numeric::kMPIMasterRank, 1);
         
         // Check if we're in MPI environment and print only from master rank
         int rank = 0;

--- a/include/qlpeps/algorithm/vmc_update/exact_summation_energy_evaluator.h
+++ b/include/qlpeps/algorithm/vmc_update/exact_summation_energy_evaluator.h
@@ -95,8 +95,9 @@ std::vector<Configuration> GenerateAllPermutationConfigs(
 }
 
 /**
- * @brief Single-process exact summation energy evaluator (RESTORED after MPI cleanup)
- *
+ * @brief MPI-enabled exact summation energy evaluator (Parallel for the summation over all configurations)
+ * Degenerate to single-process evaluator when mpi_size == 1 && rank == 0
+ * 
  * Mathematical convention (consistent with the MC-based evaluator):
  * \f[
  *   \Psi(S;\,\theta),\quad w(S) = \frac{|\Psi(S)|^2}{Z},\quad Z = \sum_S |\Psi(S)|^2.
@@ -137,102 +138,17 @@ std::vector<Configuration> GenerateAllPermutationConfigs(
  *   - \(S_O\)  ↔  Ostar_weighted_sum
  *   - \(S_{EO}\)  ↔  ELocConj_Ostar_weighted_sum
  *
- * @tparam ModelT The model type (must have CalEnergyAndHoles method)
- * @tparam TenElemT Tensor element type (double or complex)
- * @tparam QNT Quantum number type (fZ2QN-like for fermions, TrivialRepQN/U1 variants for bosons)
- * @param split_index_tps The current PEPS state
- * @param all_configs All possible configurations to sum over
- * @param trun_para BMPS truncation parameters
- * @param model The physical model
- * @param Ly Number of rows in the lattice
- * @param Lx Number of columns in the lattice
- * @return Tuple of (energy, gradient, error) where error is always 0 for exact summation
- */
-template<typename ModelT, typename TenElemT, typename QNT>
-std::tuple<TenElemT, SplitIndexTPS<TenElemT, QNT>, double> ExactSumEnergyEvaluator(
-    const SplitIndexTPS<TenElemT, QNT> &split_index_tps,
-    const std::vector<Configuration> &all_configs,
-    const BMPSTruncatePara &trun_para,
-    ModelT &model,
-    size_t Ly, size_t Lx
-) {
-  using SplitIndexTPSType = SplitIndexTPS<TenElemT, QNT>;
-
-  std::vector<double> weights;
-  std::vector<TenElemT> e_loc_set;
-  // Accumulators: S_O and S_{EO} (see Doxygen above)
-  SplitIndexTPSType Ostar_weighted_sum(Ly, Lx, split_index_tps.PhysicalDim());            // S_O
-  SplitIndexTPSType ELocConj_Ostar_weighted_sum(Ly, Lx, split_index_tps.PhysicalDim());   // S_{EO}
-
-  // Exact summation over all configurations
-  for (auto &config : all_configs) {
-    TPSWaveFunctionComponent<TenElemT, QNT>
-        tps_sample(split_index_tps, config, trun_para);
-    weights.push_back(std::norm(tps_sample.amplitude));
-    TensorNetwork2D<TenElemT, QNT> holes_dag(Ly, Lx);// \partial_{theta^*} \Psi^*
-    TenElemT e_loc =
-        model.template CalEnergyAndHoles<TenElemT, QNT, true>(
-            &split_index_tps, &tps_sample, holes_dag);
-    e_loc_set.push_back(e_loc);
-
-    // Per-configuration increment to S_O (see Doxygen mapping): O^*(S) weighted by |Ψ(S)|^2
-    SplitIndexTPSType Ostar_weighted_increment(Ly, Lx, split_index_tps.PhysicalDim());
-    for (size_t row = 0; row < Ly; row++) {
-      for (size_t col = 0; col < Lx; col++) {
-        size_t basis = tps_sample.config({row, col});
-
-        // Handle gradient calculation based on particle type
-        if constexpr (Index<QNT>::IsFermionic()) {
-          // Fermion system: Use complex tensor contractions
-          auto psi_partial_psi_dag = EvaluateLocalPsiPartialPsiDag(holes_dag({row, col}), tps_sample.tn({row, col}));
-          Ostar_weighted_increment({row, col})[basis] = psi_partial_psi_dag;
-        } else {
-          // Boson system: |Psi|^2 * \Delta, where \Delta = \partial_{\theta^*} ln(\Psi^*)
-          Ostar_weighted_increment({row, col})[basis] = tps_sample.amplitude * holes_dag({row, col});
-        }
-      }
-    }
-    // S_O += w_raw(S) · O*(S)
-    Ostar_weighted_sum += Ostar_weighted_increment;
-    // S_{EO} += w_raw(S) · E_loc*(S) · O*(S)
-    ELocConj_Ostar_weighted_sum += ComplexConjugate(e_loc) * Ostar_weighted_increment;
-  }
-
-  // Calculate weighted averages
-  double weight_sum = 0.0;
-  TenElemT e_loc_sum = TenElemT(0.0);
-  for (size_t j = 0; j < e_loc_set.size(); j++) {
-    e_loc_sum += e_loc_set[j] * weights[j];
-    weight_sum += weights[j];
-  }
-  TenElemT energy = e_loc_sum / weight_sum;
-
-  // Calculate gradient
-  // (S_{EO} − E^* S_O) / W_sum
-  SplitIndexTPSType gradient = (ELocConj_Ostar_weighted_sum - ComplexConjugate(energy) * Ostar_weighted_sum) * (1.0 / weight_sum);
-
-  // Apply fermion parity operations only for fermion systems
-  if constexpr (Index<QNT>::IsFermionic()) {
-    gradient.ActFermionPOps();
-  }
-
-  return {energy, gradient, 0.0}; // Error is 0 for exact summation
-}
-
-/**
- * @brief MPI-enabled exact summation energy evaluator (Fake-parallel per contract)
- *
  * Contract (per docs/dev/design/arch/mpi-contracts.md):
- * - Input state is valid only on the master rank. The evaluator broadcasts the state to all ranks.
+ * - Input state is valid only on the master rank. The evaluator broadcasts the state to all ranks when mpi_size > 1.
  * - Return values (energy, gradient, error) are valid only on the master rank.
- * - For mpi_size == 1, this function degenerates to the single-process evaluator.
+ * - For mpi_size == 1 && rank == 0, this function degenerates to the single-process evaluator.
  *
- * Implementation (fake-parallel for testing):
+ * Implementation (Parallel for the summation over all configurations):
  * - Broadcast the state once to satisfy "who uses, who distributes".
- * - Only master rank performs the full exact summation by calling the single-process evaluator.
+ * - All ranks perform the exact summation over the configurations assigned for themselves. The master rank obtain results
+ * - from different ranks by MPI_Send and MPI_Recv for SplitIndexTPSType and by MPI_Reduce for scalar data.
  * - Non-master ranks return placeholder gradient tensors (zeros). Index compatibility is not guaranteed on placeholders,
  *   because downstream Optimizer contracts require gradient validity only on master rank.
- * - No static partitioning or point-to-point communication is used here.
  *
  * Rationale:
  * - This helper is designed for tests to verify Evaluator correctness independently of MC sampling.
@@ -241,9 +157,9 @@ std::tuple<TenElemT, SplitIndexTPS<TenElemT, QNT>, double> ExactSumEnergyEvaluat
  *
  * @tparam ModelT The model type (must have CalEnergyAndHoles method)
  * @tparam TenElemT Tensor element type (double or complex)
- * @tparam QNT Quantum number type
- * @param split_index_tps_master_only State valid only on master
- * @param all_configs All configurations to enumerate
+ * @tparam QNT Quantum number type (fZ2QN-like for fermions, TrivialRepQN/U1 variants for bosons)
+ * @param split_index_tps_master_only The current PEPS state valid only on master
+ * @param all_configs All configurations to enumerate. Should be valid on all ranks.
  * @param trun_para BMPS truncation parameters
  * @param model Physical model
  * @param Ly Lattice rows
@@ -251,7 +167,7 @@ std::tuple<TenElemT, SplitIndexTPS<TenElemT, QNT>, double> ExactSumEnergyEvaluat
  * @param comm MPI communicator
  * @param rank MPI rank
  * @param mpi_size MPI world size
- * @return (energy, gradient, error) valid only at master rank. Others return placeholders.
+ * @return (energy, gradient, error) valid only at master rank. Others return placeholders. Error is always 0 for exact summation.
  */
 template<typename ModelT, typename TenElemT, typename QNT>
 std::tuple<TenElemT, SplitIndexTPS<TenElemT, QNT>, double> ExactSumEnergyEvaluatorMPI(
@@ -267,18 +183,12 @@ std::tuple<TenElemT, SplitIndexTPS<TenElemT, QNT>, double> ExactSumEnergyEvaluat
 ) {
   using SplitIndexTPSType = SplitIndexTPS<TenElemT, QNT>;
 
-  // Degenerate to single-process evaluator when mpi_size == 1
-  if (mpi_size == 1) {
-    return ExactSumEnergyEvaluator<ModelT, TenElemT, QNT>(
-        split_index_tps_master_only, all_configs, trun_para, model, Ly, Lx);
-  }
-
-  // Broadcast input state from master to all ranks (to satisfy contract; computation remains master-only)
+  // Broadcast input state from master to all ranks when mpi_size > 1 (to satisfy contract; computation remains master-only)
   SplitIndexTPSType split_index_tps_bcast;
   if (rank == qlten::hp_numeric::kMPIMasterRank) {
     split_index_tps_bcast = split_index_tps_master_only;
   }
-  qlpeps::MPI_Bcast(split_index_tps_bcast, comm, qlten::hp_numeric::kMPIMasterRank);
+  if (mpi_size > 1) qlpeps::MPI_Bcast(split_index_tps_bcast, comm, qlten::hp_numeric::kMPIMasterRank);
 
   std::vector<double> weights;
   std::vector<TenElemT> e_loc_set;
@@ -330,40 +240,49 @@ std::tuple<TenElemT, SplitIndexTPS<TenElemT, QNT>, double> ExactSumEnergyEvaluat
     weight_rank += weights[j];
   }
 
-  //Receive S_O and S_{EO} from different ranks and calculate the sum
-  if (rank == qlten::hp_numeric::kMPIMasterRank) {
-    for (size_t source = 1; source < mpi_size; source++) {
-      SplitIndexTPSType Ostar_weighted_rank;            // S_O of different ranks
-      SplitIndexTPSType ELocConj_Ostar_weighted_rank;   // S_{EO} of different ranks
-      MPI_Status status_Ostar_weighted = qlpeps::MPI_Recv(Ostar_weighted_rank, source, comm, 0);
-      MPI_Status status_ELocConj_Ostar_weighted = qlpeps::MPI_Recv(ELocConj_Ostar_weighted_rank, source, comm, 1);
-      Ostar_weighted_sum += Ostar_weighted_rank;
-      ELocConj_Ostar_weighted_sum += ELocConj_Ostar_weighted_rank;
-    }
-  } else {
-    qlpeps::MPI_Send(Ostar_weighted_sum, qlten::hp_numeric::kMPIMasterRank, comm, 0);
-    qlpeps::MPI_Send(ELocConj_Ostar_weighted_sum, qlten::hp_numeric::kMPIMasterRank, comm, 1);
-  }
-  
   double weight_sum = 0.0;
   TenElemT e_loc_sum = TenElemT(0.0);
-  HANDLE_MPI_ERROR(::MPI_Reduce(&weight_rank, 
-                                &weight_sum, 
-                                1, 
-                                MPI_DOUBLE, 
-                                MPI_SUM, 
-                                qlten::hp_numeric::kMPIMasterRank, 
-                                comm));
-  HANDLE_MPI_ERROR(::MPI_Reduce(&e_loc_rank, 
-                                &e_loc_sum, 
-                                1, 
-                                hp_numeric::GetMPIDataType<TenElemT>(), 
-                                MPI_SUM, 
-                                qlten::hp_numeric::kMPIMasterRank, 
-                                comm));
+
+  if (mpi_size > 1) {
+
+    //Receive S_O and S_{EO} from different ranks when mpi_size > 1 and calculate the sum
+    if (rank == qlten::hp_numeric::kMPIMasterRank) {
+      for (size_t source = 1; source < mpi_size; source++) {
+        SplitIndexTPSType Ostar_weighted_rank;            // S_O of different ranks
+        SplitIndexTPSType ELocConj_Ostar_weighted_rank;   // S_{EO} of different ranks
+        MPI_Status status_Ostar_weighted = qlpeps::MPI_Recv(Ostar_weighted_rank, source, comm, source);
+        MPI_Status status_ELocConj_Ostar_weighted = qlpeps::MPI_Recv(ELocConj_Ostar_weighted_rank, source, comm, mpi_size + source);
+        Ostar_weighted_sum += Ostar_weighted_rank;
+        ELocConj_Ostar_weighted_sum += ELocConj_Ostar_weighted_rank;
+      }
+    } else {
+      qlpeps::MPI_Send(Ostar_weighted_sum, qlten::hp_numeric::kMPIMasterRank, comm, rank);
+      qlpeps::MPI_Send(ELocConj_Ostar_weighted_sum, qlten::hp_numeric::kMPIMasterRank, comm, mpi_size + rank);
+    }
+
+    //Calculate the sum of weight and e_loc of different ranks when mpi_size > 1
+    HANDLE_MPI_ERROR(::MPI_Reduce(&weight_rank, 
+                                  &weight_sum, 
+                                  1, 
+                                  MPI_DOUBLE, 
+                                  MPI_SUM, 
+                                  qlten::hp_numeric::kMPIMasterRank, 
+                                  comm));
+    HANDLE_MPI_ERROR(::MPI_Reduce(&e_loc_rank, 
+                                  &e_loc_sum, 
+                                  1, 
+                                  hp_numeric::GetMPIDataType<TenElemT>(), 
+                                  MPI_SUM, 
+                                  qlten::hp_numeric::kMPIMasterRank, 
+                                  comm));
+  } else {
+    weight_sum = weight_rank;
+    e_loc_sum  = e_loc_rank;
+  }
 
   if (rank == qlten::hp_numeric::kMPIMasterRank) {
 
+    // Calculate weighted averages
     TenElemT energy = e_loc_sum / weight_sum;
 
     // Calculate gradient

--- a/tests/test_algorithm/test_mc_energy_grad_evaluator.cpp
+++ b/tests/test_algorithm/test_mc_energy_grad_evaluator.cpp
@@ -274,13 +274,16 @@ TEST_F(SpinlessFermionExactVsMCTest, EnergyAndGradientMatch) {
                                     std::make_optional<double>(1e-14),
                                     std::make_optional<size_t>(10));
   std::vector<Configuration> all_configs = GenerateAllPermutationConfigs({2, 2}, Lx, Ly);
-  auto [energy_exact, grad_exact, err_exact] = ExactSumEnergyEvaluator<SquareSpinlessFermion, TenElemT, QNT>(
+  auto [energy_exact, grad_exact, err_exact] = ExactSumEnergyEvaluatorMPI<SquareSpinlessFermion, TenElemT, QNT>(
     sitps,
     all_configs,
     trun_para,
     model,
     Ly,
-    Lx);
+    Lx,
+    comm,
+    qlten::hp_numeric::kMPIMasterRank,
+    1);
 
   // 3) MC evaluator with moderate samples (fast + stable)
   Configuration half_filling(Ly, Lx);

--- a/tests/test_optimizer/test_optimizer_adagrad_exact_sum.cpp
+++ b/tests/test_optimizer/test_optimizer_adagrad_exact_sum.cpp
@@ -321,13 +321,16 @@ TEST_F(Z2SpinlessFreeFermionTools, ExactSumGradientOptWithVMCOptimizer) {
     auto &split_index_tps = split_index_tps_list[i];
 
     // RESTORED: Single-process ExactSumEnergyEvaluator call (memory-safe)
-    auto [initial_energy, initial_gradient, initial_error] = ExactSumEnergyEvaluator(
+    auto [initial_energy, initial_gradient, initial_error] = ExactSumEnergyEvaluatorMPI(
       split_index_tps,
       all_configs,
       trun_para,
       spinless_fermion_model,
       Ly,
-      Lx);
+      Lx,
+      this->comm,
+      hp_numeric::kMPIMasterRank,
+      1);
 
     std::cout << "Initial energy: " << initial_energy << ", Expected: " << energy_exact << std::endl;
     std::cout << "Initial gradient norm: " << initial_gradient.NormSquare() << std::endl;


### PR DESCRIPTION
1. Change ExactSumEnergyEvaluatorMPI to assign the exact summation over all configurations to different ranks. And do final summation on master, by using MPI_Send, MPI_Recv for SplitIndexTPSType, and MPI_Reduce for scalar data;
2. Unify ExactSumEnergyEvaluator and ExactSumEnergyEvaluatorMPI into a single interface named ExactSumEnergyEvaluatorMPI;
3. Change the ExactSumEnergyEvaluator used in some code files to ExactSumEnergyEvaluatorMPI with rank = 0 and mpi_size = 1