### PR TITLE
Dev/nnn simple update

### DIFF
--- a/include/qlpeps/algorithm/simple_update/square_lattice_nnn_simple_update.h
+++ b/include/qlpeps/algorithm/simple_update/square_lattice_nnn_simple_update.h
@@ -342,16 +342,11 @@ typename SquareLatticeNNNSimpleUpdateExecutor<TenElemT, QNT>::RealT SquareLattic
       e0 += proj_res1.e_loc.value();
       norm *= proj_res1.norm;
       max_trunc_err = std::max(max_trunc_err, proj_res1.trunc_err);
-      
-      ProjectionRes<TenElemT>
-          proj_res2 = this->peps_.UpperLeftTriangleProject(evolve_gate_upperleft_tri_({row, col}), 
-                                                          {row, col}, 
-                                                           para, 
-                                                           ham_upperleft_tri_({row, col}));
-      e0 += proj_res2.e_loc.value();
-      norm *= proj_res2.norm;
-      max_trunc_err = std::max(max_trunc_err, proj_res2.trunc_err);
+    }
+  }
 
+  for (size_t col = 0; col < hor_bond_limit; col++) {
+    for (size_t row = 0; row < ver_bond_limit; row++) {
       ProjectionRes<TenElemT>
           proj_res3 = this->peps_.LowerRightTriangleProject(evolve_gate_lowerright_tri_({row, col}), 
                                                            {row, (col + 1) % this->peps_.lambda_horiz.cols()}, 
@@ -360,7 +355,11 @@ typename SquareLatticeNNNSimpleUpdateExecutor<TenElemT, QNT>::RealT SquareLattic
       e0 += proj_res3.e_loc.value();
       norm *= proj_res3.norm;
       max_trunc_err = std::max(max_trunc_err, proj_res3.trunc_err);
+    }
+  }
 
+  for (size_t col = 0; col < hor_bond_limit; col++) {
+    for (size_t row = 0; row < ver_bond_limit; row++) {
       ProjectionRes<TenElemT>
           proj_res4 = this->peps_.LowerLeftTriangleProject(evolve_gate_lowerleft_tri_({row, col}), 
                                                           {row, col}, 
@@ -369,6 +368,19 @@ typename SquareLatticeNNNSimpleUpdateExecutor<TenElemT, QNT>::RealT SquareLattic
       e0 += proj_res4.e_loc.value();
       norm *= proj_res4.norm;
       max_trunc_err = std::max(max_trunc_err, proj_res4.trunc_err);
+    }
+  }
+
+  for (size_t col = 0; col < hor_bond_limit; col++) {
+    for (size_t row = 0; row < ver_bond_limit; row++) {
+      ProjectionRes<TenElemT>
+          proj_res2 = this->peps_.UpperLeftTriangleProject(evolve_gate_upperleft_tri_({row, col}), 
+                                                          {row, col}, 
+                                                           para, 
+                                                           ham_upperleft_tri_({row, col}));
+      e0 += proj_res2.e_loc.value();
+      norm *= proj_res2.norm;
+      max_trunc_err = std::max(max_trunc_err, proj_res2.trunc_err);
     }
   }
 

--- a/include/qlpeps/algorithm/simple_update/square_lattice_nnn_simple_update.h
+++ b/include/qlpeps/algorithm/simple_update/square_lattice_nnn_simple_update.h
@@ -182,38 +182,46 @@ class SquareLatticeNNNSimpleUpdateExecutor : public SimpleUpdateExecutor<TenElem
     Contract(&ham_nn_, {}, &id, {}, &tri_ham_nn_2);
     size_t hor_bond_tri_num = 4; // Number of triangle shared the horizontal NN bond
     size_t ver_bond_tri_num = 4; // Number of triangle shared the vertical NN bond
-    if (!is_pbc) {
-      switch (triposition) {
-        case UpperLeft: {
+    
+    switch (triposition) {
+      case UpperLeft: {
+        if (!is_pbc) {
           if(site_b[0] == 0) hor_bond_tri_num = 2;
           if(site_b[1] == 0) ver_bond_tri_num = 2;
-          hor_ham_nn = tri_ham_nn_2 * (RealT(1) / RealT(hor_bond_tri_num));
-          ver_ham_nn = tri_ham_nn_1 * (RealT(1) / RealT(ver_bond_tri_num));
-          break;
         }
-        case UpperRight: {
+        hor_ham_nn = tri_ham_nn_2 * (RealT(1) / RealT(hor_bond_tri_num));
+        ver_ham_nn = tri_ham_nn_1 * (RealT(1) / RealT(ver_bond_tri_num));
+        break;
+      }
+      case UpperRight: {
+        if (!is_pbc) {
           if(site_b[0] == 0) hor_bond_tri_num = 2;
           if(site_b[1] == this->lx_ - 1) ver_bond_tri_num = 2;
-          hor_ham_nn = tri_ham_nn_2 * (RealT(1) / RealT(hor_bond_tri_num));
-          ver_ham_nn = tri_ham_nn_1 * (RealT(1) / RealT(ver_bond_tri_num));
-          break;
         }
-        case LowerLeft: {
+        hor_ham_nn = tri_ham_nn_2 * (RealT(1) / RealT(hor_bond_tri_num));
+        ver_ham_nn = tri_ham_nn_1 * (RealT(1) / RealT(ver_bond_tri_num));
+        break;
+      }
+      case LowerLeft: {
+        if (!is_pbc) {
           if(site_b[0] == this->ly_ - 1) hor_bond_tri_num = 2;
           if(site_b[1] == 0) ver_bond_tri_num = 2;
-          hor_ham_nn = tri_ham_nn_1 * (RealT(1) / RealT(hor_bond_tri_num));
-          ver_ham_nn = tri_ham_nn_2 * (RealT(1) / RealT(ver_bond_tri_num));
-          break;
         }
-        case LowerRight: {
+        hor_ham_nn = tri_ham_nn_1 * (RealT(1) / RealT(hor_bond_tri_num));
+        ver_ham_nn = tri_ham_nn_2 * (RealT(1) / RealT(ver_bond_tri_num));
+        break;
+      }
+      case LowerRight: {
+        if (!is_pbc) {
           if(site_b[0] == this->ly_ - 1) hor_bond_tri_num = 2;
           if(site_b[1] == this->lx_ - 1) ver_bond_tri_num = 2;
-          hor_ham_nn = tri_ham_nn_1 * (RealT(1) / RealT(hor_bond_tri_num));
-          ver_ham_nn = tri_ham_nn_2 * (RealT(1) / RealT(ver_bond_tri_num));
-          break;
         }
+        hor_ham_nn = tri_ham_nn_1 * (RealT(1) / RealT(hor_bond_tri_num));
+        ver_ham_nn = tri_ham_nn_2 * (RealT(1) / RealT(ver_bond_tri_num));
+        break;
       }
     }
+    
 
      // on-site term
     if (ham_on_site_terms_(0, 0) == nullptr || ham_on_site_terms_(0, 0)->IsDefault()) {

--- a/include/qlpeps/algorithm/simple_update/square_lattice_nnn_simple_update.h
+++ b/include/qlpeps/algorithm/simple_update/square_lattice_nnn_simple_update.h
@@ -132,19 +132,23 @@ class SquareLatticeNNNSimpleUpdateExecutor : public SimpleUpdateExecutor<TenElem
       case UpperLeft: {
         tri_site[0] = {site_b[0], (site_b[1] + 1) % this->peps_.lambda_horiz.cols()};
         tri_site[2] = {(site_b[0] + 1) % this->peps_.lambda_vert.rows(), site_b[1]};
+        break;
       }
       case UpperRight: {
         tri_site[0] = {site_b[0], (site_b[1] - 1 + this->peps_.lambda_horiz.cols()) % this->peps_.lambda_horiz.cols()};
         tri_site[2] = {(site_b[0] + 1) % this->peps_.lambda_vert.rows(), site_b[1]};
+        break;
       }
       case LowerLeft: {
         tri_site[0] = {(site_b[0] - 1 + this->peps_.lambda_vert.rows()) % this->peps_.lambda_vert.rows(), site_b[1]};
         tri_site[2] = {(site_b[0] - 1 + this->peps_.lambda_vert.rows()) % this->peps_.lambda_vert.rows(), 
                        (site_b[1] + 1) % this->peps_.lambda_horiz.cols()};
+        break;
       }
       case LowerRight: {
         tri_site[0] = {(site_b[0] - 1 + this->peps_.lambda_vert.rows()) % this->peps_.lambda_vert.rows(), site_b[1]};
         tri_site[2] = {site_b[0], (site_b[1] - 1 + this->peps_.lambda_horiz.cols()) % this->peps_.lambda_horiz.cols()};
+        break;
       }
     }
 
@@ -185,24 +189,28 @@ class SquareLatticeNNNSimpleUpdateExecutor : public SimpleUpdateExecutor<TenElem
           if(site_b[1] == 0) ver_bond_tri_num = 2;
           hor_ham_nn = tri_ham_nn_2 * (RealT(1) / RealT(hor_bond_tri_num));
           ver_ham_nn = tri_ham_nn_1 * (RealT(1) / RealT(ver_bond_tri_num));
+          break;
         }
         case UpperRight: {
           if(site_b[0] == 0) hor_bond_tri_num = 2;
           if(site_b[1] == this->lx_ - 1) ver_bond_tri_num = 2;
           hor_ham_nn = tri_ham_nn_2 * (RealT(1) / RealT(hor_bond_tri_num));
           ver_ham_nn = tri_ham_nn_1 * (RealT(1) / RealT(ver_bond_tri_num));
+          break;
         }
         case LowerLeft: {
           if(site_b[0] == this->ly_ - 1) hor_bond_tri_num = 2;
           if(site_b[1] == 0) ver_bond_tri_num = 2;
           hor_ham_nn = tri_ham_nn_1 * (RealT(1) / RealT(hor_bond_tri_num));
           ver_ham_nn = tri_ham_nn_2 * (RealT(1) / RealT(ver_bond_tri_num));
+          break;
         }
         case LowerRight: {
           if(site_b[0] == this->ly_ - 1) hor_bond_tri_num = 2;
           if(site_b[1] == this->lx_ - 1) ver_bond_tri_num = 2;
           hor_ham_nn = tri_ham_nn_1 * (RealT(1) / RealT(hor_bond_tri_num));
           ver_ham_nn = tri_ham_nn_2 * (RealT(1) / RealT(ver_bond_tri_num));
+          break;
         }
       }
     }

--- a/include/qlpeps/algorithm/simple_update/square_lattice_nnn_simple_update.h
+++ b/include/qlpeps/algorithm/simple_update/square_lattice_nnn_simple_update.h
@@ -36,76 +36,232 @@ class SquareLatticeNNNSimpleUpdateExecutor : public SimpleUpdateExecutor<TenElem
   SquareLatticeNNNSimpleUpdateExecutor(const SimpleUpdatePara &update_para,
                                        const PEPST &peps_initial,
                                        const Tensor &ham_nn,
-                                       const Tensor &ham_nnn) :
-      SimpleUpdateExecutor<TenElemT, QNT>(update_para, peps_initial), \
-                                           ham_nn_(ham_nn) {
-    /*      1             3
-            |             |
-            v             v
-            |---ham_nnn---|
-            v             v
-            |             |
-            0             2
-     */
-    Tensor id = Eye<TenElemT>(ham_nn.GetIndex(0));
-    if (Tensor::IsFermionic() && id.GetIndex(0).GetDir() == OUT) { //should be
-      id.ActFermionPOps();
+                                       const Tensor &ham_nnn,
+                                       const Tensor &ham_onsite = Tensor()) :
+    SimpleUpdateExecutor<TenElemT, QNT>(update_para, peps_initial),
+    ham_nn_(ham_nn), ham_nnn_(ham_nnn),
+    ham_on_site_terms_(this->ly_, this->lx_),
+    ham_lowerright_tri_(this->ly_ - 1, this->lx_),
+    ham_lowerleft_tri_(this->ly_ - 1, this->lx_ - 1),
+    evolve_gate_lowerright_tri_(this->ly_ - 1, this->lx_),
+    evolve_gate_lowerleft_tri_(this->ly_ - 1, this->lx_ - 1) {
+    if (!ham_onsite.IsDefault())
+    for (auto &ten : ham_on_site_terms_) {
+      ten = ham_onsite;
     }
-    Tensor extend_ham_nnn, extend_ham_nn_left, extend_ham_nn_right;
-    Contract(&ham_nnn, {}, &id, {}, &extend_ham_nnn);
-    extend_ham_nnn.Transpose({0, 1, 4, 5, 2, 3});
-    Contract(&ham_nn, {}, &id, {}, &extend_ham_nn_left);
-    Contract(&id, {}, &ham_nn, {}, &extend_ham_nn_right);
-    ham_tri_ = extend_ham_nnn + RealT(0.5) * extend_ham_nn_right + RealT(0.5) * extend_ham_nn_left;
   }
+  /**
+   * The case containing non-uniform on-site terms, like pinning field.
+   */
+  SquareLatticeNNNSimpleUpdateExecutor(const SimpleUpdatePara &update_para,
+                                       const PEPST &peps_initial,
+                                       const Tensor &ham_nn,
+                                       const Tensor &ham_nnn,
+                                       const TenMatrix<Tensor> &ham_onsite_terms) :
+    SimpleUpdateExecutor<TenElemT, QNT>(update_para, peps_initial),
+    ham_nn_(ham_nn), ham_nnn_(ham_nnn),
+    ham_on_site_terms_(ham_onsite_terms),
+    ham_lowerright_tri_(this->ly_ - 1, this->lx_),
+    ham_lowerleft_tri_(this->ly_ - 1, this->lx_ - 1),
+    evolve_gate_lowerright_tri_(this->ly_ - 1, this->lx_),
+    evolve_gate_lowerleft_tri_(this->ly_ - 1, this->lx_ - 1) {
+      assert(ham_on_site_terms_.rows() == this->ly_);
+      assert(ham_on_site_terms_.cols() == this->lx_);
+    }
 
  private:
-  void SetEvolveGate_(void) override {
-    evolve_gate_nn_ = TaylorExpMatrix(RealT(this->update_para.tau), ham_nn_);
-    evolve_gate_nn_half_ = TaylorExpMatrix(RealT(this->update_para.tau) / 2, ham_nn_);
-    evolve_gate_tri_ = TaylorExpMatrix(RealT(this->update_para.tau), ham_tri_);
+ void SetEvolveGate_(void) override;
+  // void SetEvolveGate_(void) override {
+  //   evolve_gate_nn_ = TaylorExpMatrix(this->update_para.tau, ham_nn_);
+  //   evolve_gate_nn_half_ = TaylorExpMatrix(this->update_para.tau / 2, ham_nn_);
+  //   evolve_gate_tri_ = TaylorExpMatrix(this->update_para.tau, ham_tri_);
+  // }
+
+  /**
+   * @return h_{ABC} = ham_{nnn}^A \otimes id \otimes ham_{nnn}^C
+   *                 + id \otimes ham_{nn}^{BC} / BondTri\_horizontal
+   *                 + ham_{nn}^{AB} \otimes id / BondTri\_vertical
+   *                 + ham\_on\_site\_terms_A \otimes id \otimes id / site\_share\_tri_A
+   *                 + id \otimes ham\_on\_site\_terms_B \otimes id / site\_share\_tri_B
+   *                 + id \otimes id \otimes ham\_on\_site\_terms_C / site\_share\_tri_C
+   *
+   *     LowerLeftTriangle                       LowerRightTriangle
+   *      (LeftRight == 0)                         (LeftRight == 1)
+   *      |             |                          |             |
+   *      |             |                          |             |
+   * -----A----------------------             -------------------A--------
+   *      |             |                          |             |
+   *      |             |                          |             |
+   *      |             |                          |             |
+   * -----B-------------C--------             -----C-------------B--------
+   *      |             |                          |             |
+   *      |             |                          |             |
+   */
+  Tensor ConstructTriHamiltonian(const SiteIdx &upper_site, const size_t LeftRight) const {
+    Tensor extend_ham_nnn, extend_ham_nn_horizontal, extend_ham_nn_vertical;
+    std::vector<SiteIdx> tri_site(3);
+
+    tri_site[0] = upper_site;
+    if (LeftRight == 0) { // LowerLeft
+      tri_site[1] = {upper_site[0] + 1, upper_site[1]};
+      tri_site[2] = {upper_site[0] + 1, upper_site[1] + 1};
+    } else { // LowerRight
+      tri_site[1] = {upper_site[0] + 1, upper_site[1]};
+      tri_site[2] = {upper_site[0] + 1, upper_site[1] - 1};
+    }
+
+    Tensor id = Eye<TenElemT>(ham_nn_.GetIndex(0)); // assume uniform hilbert space.
+    if (Tensor::IsFermionic() && id.GetIndex(0).GetDir() != OUT) {
+      std::cerr << "Index direction of identity operator is unexpected." << std::endl;
+    }
+    if (Tensor::IsFermionic()) {
+      id.ActFermionPOps();
+    }
+
+    // NNN term
+    /*      1             3             5              1             3             5
+            |             |             |              |             |             |
+            v             v             v              v             v             v
+            |             |             |   Transpose  |             |             |
+            A---ham_nnn---C-----------id(B) -------->  A------------id(B)----------C
+            |             |             |              |             |             |
+            v             v             v              v             v             v
+            |             |             |              |             |             |
+            0             2             4              0             2             4
+     */
+    Contract(&ham_nnn_, {}, &id, {}, &extend_ham_nnn);
+    extend_ham_nnn.Transpose({0, 1, 4, 5, 2, 3});
+
+    // NN term
+    size_t BondTri_horizontal = 2; // Number of triangle shared the horizontal NN bond
+    size_t BondTri_vertical = 2; // Number of triangle shared the vertical NN bond
+    if (LeftRight == 0 && upper_site[1] == 0) BondTri_vertical = 1; // LowerLeft, first column
+    else if (LeftRight == 1 && upper_site[1] == this->lx_ - 1) BondTri_vertical = 1; // LowerRight, last column
+
+    Contract(&id, {}, &ham_nn_, {}, &extend_ham_nn_horizontal);
+    extend_ham_nn_horizontal *= static_cast<TenElemT>(RealT(1.0 / static_cast<double>(BondTri_horizontal)));
+    Contract(&ham_nn_, {}, &id, {}, &extend_ham_nn_vertical);
+    extend_ham_nn_vertical *= static_cast<TenElemT>(RealT(1.0 / static_cast<double>(BondTri_vertical)));
+
+     // on-site term
+    if (ham_on_site_terms_(0, 0) == nullptr || ham_on_site_terms_(0, 0)->IsDefault()) {
+      return extend_ham_nnn + extend_ham_nn_horizontal + extend_ham_nn_vertical;
+    } else {
+      Tensor term1, term2, term3;
+      Tensor extend_on_site1, extend_on_site2, extend_on_site3;
+
+      std::vector<size_t> site_share_tri(3, 6); // Number of triangle shared the site
+      for (size_t i = 0; i < tri_site.size(); i++) {
+        const SiteIdx &site = tri_site[i];
+        if(site[0] == 0 && site[1] > 0 && site[1] < this->lx_ - 1) 
+          site_share_tri[i] = 2; // first row
+        else if(site[1] == 0 && site[0] > 0 && site[0] < this->ly_ - 1) 
+          site_share_tri[i] = 3; // first column
+        else if(site[1] == this->lx_ - 1 && site[0] > 0 && site[0] < this->ly_ - 1) 
+          site_share_tri[i] = 3; // last column
+        else if(site[0] == 0 && (site[1] == 0 || site[1] == this->lx_ - 1))
+          site_share_tri[i] = 1; // corner site on the first row
+        else if(site[0] == this->ly_ - 1 && (site[1] == 0 || site[1] == this->lx_ - 1))
+          site_share_tri[i] = 2; // corner site on the last row
+      }
+
+      // site A
+      const Tensor & on_site_term1 = ham_on_site_terms_({tri_site[0][0], tri_site[0][1]});
+      Contract(&on_site_term1, {}, &id, {}, &term1);
+      Contract(&term1, {}, &id, {}, &extend_on_site1);
+      extend_on_site1 *=  RealT(static_cast<TenElemT>(1.0 / static_cast<double>(site_share_tri[0])));
+      // site B
+      const Tensor & on_site_term2 = ham_on_site_terms_({tri_site[1][0], tri_site[1][1]});
+      Contract(&id, {}, &on_site_term2, {}, &term2);
+      Contract(&term2, {}, &id, {}, &extend_on_site2);
+      extend_on_site2 *=  RealT(static_cast<TenElemT>(1.0 / static_cast<double>(site_share_tri[1])));
+      // site C
+      const Tensor & on_site_term3 = ham_on_site_terms_({tri_site[2][0], tri_site[2][1]});
+      Contract(&id, {}, &id, {}, &term3);
+      Contract(&term3, {}, &on_site_term3, {}, &extend_on_site3);
+      extend_on_site3 *= RealT(static_cast<TenElemT>(1.0 / static_cast<double>(site_share_tri[2])));
+
+      return extend_ham_nnn + extend_ham_nn_horizontal + extend_ham_nn_vertical
+          + extend_on_site1 + extend_on_site2 + extend_on_site3;
+    }
+  }
+
+  Tensor ConstructEvolveOperator(const SiteIdx &upper_site, const size_t LeftRight) const {
+    return TaylorExpMatrix(RealT(this->update_para.tau), ConstructTriHamiltonian(upper_site, LeftRight));
   }
 
   RealT SimpleUpdateSweep_(void) override;
 
-  Tensor ham_nn_;
-  Tensor ham_tri_;// Hamiltonian term on A-B-C 3-site,
-    //with A-B and B-C are NN bonds, A-C is NNN bond.
-  // ham_tri_ term contains half of J1 interaction on bond A-B and B-C,
-  // while contain the whole of J2 interaction on bond A-C
+  Tensor ham_nn_;   // uniform NN interaction
+  Tensor ham_nnn_;  // uniform NNN interaction
+  TenMatrix<Tensor> ham_on_site_terms_;  // on-site terms
+
+  TenMatrix<Tensor> ham_lowerright_tri_;
+  TenMatrix<Tensor> ham_lowerleft_tri_;
+  // A-B-C 3-site, A-B and B-C are NN connect, A-C is NNN connect
+  // A-B or B-C has half of J1 interaction, A-C has a J2 interaction
+  // A, B and C also have on-site interaction
+
   Tensor evolve_gate_nn_;
-  Tensor evolve_gate_nn_half_;  // half of J1 interaction
-  Tensor evolve_gate_tri_;
+  TenMatrix<Tensor> evolve_gate_lowerright_tri_;
+  TenMatrix<Tensor> evolve_gate_lowerleft_tri_;
 };
+
+template<typename TenElemT, typename QNT>
+void SquareLatticeNNNSimpleUpdateExecutor<TenElemT, QNT>::SetEvolveGate_(void) {
+  evolve_gate_nn_ = TaylorExpMatrix(RealT(this->update_para.tau), ham_nn_);
+  
+  for (size_t col = 0; col < this->lx_ - 1; col++) {
+    for (size_t row = 0; row < this->ly_ - 1; row++) {
+      ham_lowerright_tri_({row, col + 1}) = ConstructTriHamiltonian({row, col + 1}, 1);
+      evolve_gate_lowerright_tri_({row, col + 1}) = ConstructEvolveOperator({row, col + 1}, 1);
+      ham_lowerleft_tri_({row, col}) = ConstructTriHamiltonian({row, col}, 0);
+      evolve_gate_lowerleft_tri_({row, col}) = ConstructEvolveOperator({row, col}, 0);
+    }
+  }
+  
+}
 
 template<typename TenElemT, typename QNT>
 typename SquareLatticeNNNSimpleUpdateExecutor<TenElemT, QNT>::RealT SquareLatticeNNNSimpleUpdateExecutor<TenElemT, QNT>::SimpleUpdateSweep_(void) {
   Timer simple_update_sweep_timer("simple_update_sweep");
   SimpleUpdateTruncatePara para(this->update_para.Dmin, this->update_para.Dmax, this->update_para.Trunc_err);
-  RealT e0 = 0.0;
+  RealT e0(0.0);
+  RealT norm = 1.0;
+  RealT max_trunc_err = 0.0;
 
-  for (size_t col = 1; col < this->lx_; col++) {  //first row
+  for (size_t col = 0; col < this->lx_ - 1; col++) {  //first row
     ProjectionRes<TenElemT>
-        proj_res = this->peps_.NearestNeighborSiteProject(evolve_gate_nn_, {0, col - 1}, HORIZONTAL, para);
-    e0 += -std::log(proj_res.norm) / this->update_para.tau;
+        proj_res = this->peps_.NearestNeighborSiteProject(evolve_gate_nn_, {0, col}, HORIZONTAL, para, ham_nn_);
+    e0 += proj_res.e_loc.value();
+    norm *= proj_res.norm;
+    max_trunc_err = std::max(max_trunc_err, proj_res.trunc_err);
+    //e0 += -std::log(proj_res.norm) / this->update_para.tau;
   }
 
-  for (size_t row = 0; row < this->ly_ - 1; row++) {  // first and last column
-    ProjectionRes<TenElemT>
-        proj_res = this->peps_.NearestNeighborSiteProject(evolve_gate_nn_half_, {row, 0}, VERTICAL, para);
-    e0 += -std::log(proj_res.norm) / this->update_para.tau;
-    proj_res = this->peps_.NearestNeighborSiteProject(evolve_gate_nn_half_, {row, this->lx_ - 1}, VERTICAL, para);
-    e0 += -std::log(proj_res.norm) / this->update_para.tau;
-  }
+  // for (size_t row = 0; row < this->ly_ - 1; row++) {  // first and last column
+  //   ProjectionRes<TenElemT>
+  //       proj_res = this->peps_.NearestNeighborSiteProject(evolve_gate_nn_half_, {row, 0}, VERTICAL, para);
+  //   e0 += -std::log(proj_res.norm) / this->update_para.tau;
+  //   proj_res = this->peps_.NearestNeighborSiteProject(evolve_gate_nn_half_, {row, this->lx_ - 1}, VERTICAL, para);
+  //   e0 += -std::log(proj_res.norm) / this->update_para.tau;
+  // }
 
-  for (size_t col = 1; col < this->lx_; col++) {
+  for (size_t col = 0; col < this->lx_ - 1; col++) {
     for (size_t row = 0; row < this->ly_ - 1; row++) {
       ProjectionRes<TenElemT>
-          proj_res = this->peps_.LowerRightTriangleProject(evolve_gate_tri_, {row, col}, para);
-      e0 += -std::log(proj_res.norm) / this->update_para.tau;
+          proj_res1 = this->peps_.LowerRightTriangleProject(evolve_gate_lowerright_tri_({row, col + 1}), {row, col + 1}, para, ham_lowerright_tri_({row, col + 1}));
+      //e0 += -std::log(proj_res.norm) / this->update_para.tau;
+      e0 += proj_res1.e_loc.value();
+      norm *= proj_res1.norm;
+      max_trunc_err = std::max(max_trunc_err, proj_res1.trunc_err);
 
-      RealT norm = this->peps_.LowerLeftTriangleProject(evolve_gate_tri_, {row, col - 1}, para);
-      e0 += -std::log(norm) / this->update_para.tau;
+      ProjectionRes<TenElemT>
+          proj_res2 = this->peps_.LowerLeftTriangleProject(evolve_gate_lowerleft_tri_({row, col}), {row, col}, para, ham_lowerleft_tri_({row, col}));
+      //e0 += -std::log(norm) / this->update_para.tau;
+      e0 += proj_res2.e_loc.value();
+      norm *= proj_res2.norm;
+      max_trunc_err = std::max(max_trunc_err, proj_res2.trunc_err);
     }
   }
 
@@ -113,11 +269,14 @@ typename SquareLatticeNNNSimpleUpdateExecutor<TenElemT, QNT>::RealT SquareLattic
   auto [dmin, dmax] = this->peps_.GetMinMaxBondDim();
   std::cout << "Estimated E0 =" << std::setw(15) << std::setprecision(kEnergyOutputPrecision) << std::fixed
             << std::right << e0
+            << "Estimated En =" << std::setw(15) << std::setprecision(kEnergyOutputPrecision) << std::fixed
+            << std::right << -std::log(norm) / RealT(this->update_para.tau)
             << " Dmin/Dmax = " << std::setw(2) << std::right << dmin << "/" << std::setw(2) << std::left << dmax
+            << " TruncErr = " << std::setprecision(2) << std::scientific << max_trunc_err << std::fixed
             << " SweepTime = " << std::setw(8) << sweep_time
             << std::endl;
 
-  return e0;
+  return qlmps::Real(e0);
 }
 }
 

--- a/include/qlpeps/algorithm/simple_update/square_lattice_nnn_simple_update.h
+++ b/include/qlpeps/algorithm/simple_update/square_lattice_nnn_simple_update.h
@@ -41,10 +41,22 @@ class SquareLatticeNNNSimpleUpdateExecutor : public SimpleUpdateExecutor<TenElem
     SimpleUpdateExecutor<TenElemT, QNT>(update_para, peps_initial),
     ham_nn_(ham_nn), ham_nnn_(ham_nnn),
     ham_on_site_terms_(this->ly_, this->lx_),
-    ham_lowerright_tri_(this->ly_ - 1, this->lx_),
-    ham_lowerleft_tri_(this->ly_ - 1, this->lx_ - 1),
-    evolve_gate_lowerright_tri_(this->ly_ - 1, this->lx_),
-    evolve_gate_lowerleft_tri_(this->ly_ - 1, this->lx_ - 1) {
+    ham_upperright_tri_(peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->ly_ : this->ly_ - 1, 
+                        peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->lx_ : this->lx_ - 1),
+    ham_upperleft_tri_(peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->ly_ : this->ly_ - 1, 
+                        peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->lx_ : this->lx_ - 1),
+    ham_lowerright_tri_(peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->ly_ : this->ly_ - 1, 
+                        peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->lx_ : this->lx_ - 1),
+    ham_lowerleft_tri_(peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->ly_ : this->ly_ - 1, 
+                        peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->lx_ : this->lx_ - 1),
+    evolve_gate_upperright_tri_(peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->ly_ : this->ly_ - 1, 
+                                peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->lx_ : this->lx_ - 1),
+    evolve_gate_upperleft_tri_(peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->ly_ : this->ly_ - 1, 
+                               peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->lx_ : this->lx_ - 1),
+    evolve_gate_lowerright_tri_(peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->ly_ : this->ly_ - 1, 
+                                peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->lx_ : this->lx_ - 1),
+    evolve_gate_lowerleft_tri_(peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->ly_ : this->ly_ - 1, 
+                               peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->lx_ : this->lx_ - 1) {
     if (!ham_onsite.IsDefault())
     for (auto &ten : ham_on_site_terms_) {
       ten = ham_onsite;
@@ -61,10 +73,22 @@ class SquareLatticeNNNSimpleUpdateExecutor : public SimpleUpdateExecutor<TenElem
     SimpleUpdateExecutor<TenElemT, QNT>(update_para, peps_initial),
     ham_nn_(ham_nn), ham_nnn_(ham_nnn),
     ham_on_site_terms_(ham_onsite_terms),
-    ham_lowerright_tri_(this->ly_ - 1, this->lx_),
-    ham_lowerleft_tri_(this->ly_ - 1, this->lx_ - 1),
-    evolve_gate_lowerright_tri_(this->ly_ - 1, this->lx_),
-    evolve_gate_lowerleft_tri_(this->ly_ - 1, this->lx_ - 1) {
+    ham_upperright_tri_(peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->ly_ : this->ly_ - 1, 
+                        peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->lx_ : this->lx_ - 1),
+    ham_upperleft_tri_(peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->ly_ : this->ly_ - 1, 
+                        peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->lx_ : this->lx_ - 1),
+    ham_lowerright_tri_(peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->ly_ : this->ly_ - 1, 
+                        peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->lx_ : this->lx_ - 1),
+    ham_lowerleft_tri_(peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->ly_ : this->ly_ - 1, 
+                        peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->lx_ : this->lx_ - 1),
+    evolve_gate_upperright_tri_(peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->ly_ : this->ly_ - 1, 
+                                peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->lx_ : this->lx_ - 1),
+    evolve_gate_upperleft_tri_(peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->ly_ : this->ly_ - 1, 
+                               peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->lx_ : this->lx_ - 1),
+    evolve_gate_lowerright_tri_(peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->ly_ : this->ly_ - 1, 
+                                peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->lx_ : this->lx_ - 1),
+    evolve_gate_lowerleft_tri_(peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->ly_ : this->ly_ - 1, 
+                               peps_initial.GetBoundaryCondition() == BoundaryCondition::Periodic ? this->lx_ : this->lx_ - 1) {
       assert(ham_on_site_terms_.rows() == this->ly_);
       assert(ham_on_site_terms_.cols() == this->lx_);
     }
@@ -77,6 +101,13 @@ class SquareLatticeNNNSimpleUpdateExecutor : public SimpleUpdateExecutor<TenElem
   //   evolve_gate_tri_ = TaylorExpMatrix(this->update_para.tau, ham_tri_);
   // }
 
+  enum TriProjPOSITION {
+    UpperRight = 0,
+    UpperLeft,
+    LowerRight,
+    LowerLeft
+  };
+
   /**
    * @return h_{ABC} = ham_{nnn}^A \otimes id \otimes ham_{nnn}^C
    *                 + id \otimes ham_{nn}^{BC} / bondtri\_horizontal
@@ -85,29 +116,40 @@ class SquareLatticeNNNSimpleUpdateExecutor : public SimpleUpdateExecutor<TenElem
    *                 + id \otimes ham\_on\_site\_terms_B \otimes id / site\_share\_tri_B
    *                 + id \otimes id \otimes ham\_on\_site\_terms_C / site\_share\_tri_C
    *
-   *     LowerLeftTriangle                       LowerRightTriangle
-   *      (leftright == 0)                         (leftright == 1)
-   *      |             |                          |             |
-   *      |             |                          |             |
-   * -----A----------------------             -------------------A--------
-   *      |             |                          |             |
-   *      |             |                          |             |
-   *      |             |                          |             |
-   * -----B-------------C--------             -----C-------------B--------
-   *      |             |                          |             |
-   *      |             |                          |             |
+   *         UpperLeft                      UpperRight                     LowerLeft                      LowerRight
+   *      |             |                |             |                |             |                |             |
+   *      |             |                |             |                |             |                |             |
+   * -----B-------------A--------   -----A-------------B--------   -----A----------------------   -------------------A--------
+   *      |             |                |             |                |             |                |             |
+   *      |             |                |             |                |             |                |             |
+   *      |             |                |             |                |             |                |             |
+   * -----C----------------------   -------------------C--------   -----B-------------C--------   -----C-------------B--------
+   *      |             |                |             |                |             |                |             |
+   *      |             |                |             |                |             |                |             |
+   * 
    */
-  Tensor ConstructTriHamiltonian(const SiteIdx &upper_site, const size_t leftright) const {
-    Tensor extend_ham_nnn, extend_ham_nn_horizontal, extend_ham_nn_vertical;
+  Tensor ConstructTriHamiltonian(const SiteIdx &site_b, const TriProjPOSITION triposition) const {
+    Tensor tri_ham_nnn, tri_ham_nn_1, tri_ham_nn_2, hor_ham_nn, ver_ham_nn;
     std::vector<SiteIdx> tri_site(3);
 
-    tri_site[0] = upper_site;
-    if (leftright == 0) { // LowerLeft
-      tri_site[1] = {upper_site[0] + 1, upper_site[1]};
-      tri_site[2] = {upper_site[0] + 1, upper_site[1] + 1};
-    } else { // LowerRight
-      tri_site[1] = {upper_site[0] + 1, upper_site[1]};
-      tri_site[2] = {upper_site[0] + 1, upper_site[1] - 1};
+    tri_site[1] = site_b;
+    switch (triposition) {
+      case UpperLeft: {
+        tri_site[0] = {site_b[0], (site_b[1] + 1) % this->lx_};
+        tri_site[2] = {(site_b[0] + 1) % this->ly_, site_b[1]};
+      }
+      case UpperRight: {
+        tri_site[0] = {site_b[0], (site_b[1] - 1 + this->lx_) % this->lx_};
+        tri_site[2] = {(site_b[0] + 1) % this->ly_, site_b[1]};
+      }
+      case LowerLeft: {
+        tri_site[0] = {(site_b[0] - 1 + this->ly_) % this->ly_, site_b[1]};
+        tri_site[2] = {(site_b[0] - 1 + this->ly_) % this->ly_, (site_b[1] + 1) % this->lx_};
+      }
+      case LowerRight: {
+        tri_site[0] = {(site_b[0] - 1 + this->ly_) % this->ly_, site_b[1]};
+        tri_site[2] = {site_b[0], (site_b[1] - 1 + this->lx_) % this->lx_};
+      }
     }
 
     Tensor id = Eye<TenElemT>(ham_nn_.GetIndex(0)); // assume uniform hilbert space.
@@ -129,65 +171,95 @@ class SquareLatticeNNNSimpleUpdateExecutor : public SimpleUpdateExecutor<TenElem
             |             |             |              |             |             |
             0             2             4              0             2             4
      */
-    Contract(&ham_nnn_, {}, &id, {}, &extend_ham_nnn);
-    extend_ham_nnn.Transpose({0, 1, 4, 5, 2, 3});
+    Contract(&ham_nnn_, {}, &id, {}, &tri_ham_nnn);
+    tri_ham_nnn *= RealT(0.5);
+    tri_ham_nnn.Transpose({0, 1, 4, 5, 2, 3});
+
+    const bool is_pbc = (this->peps_.GetBoundaryCondition() == BoundaryCondition::Periodic);
 
     // NN term
-    size_t bondtri_horizontal = 2; // Number of triangle shared the horizontal NN bond
-    size_t bondtri_vertical = 2; // Number of triangle shared the vertical NN bond
-    if (leftright == 0 && upper_site[1] == 0) bondtri_vertical = 1; // LowerLeft, first column
-    else if (leftright == 1 && upper_site[1] == this->lx_ - 1) bondtri_vertical = 1; // LowerRight, last column
-
-    Contract(&id, {}, &ham_nn_, {}, &extend_ham_nn_horizontal);
-    extend_ham_nn_horizontal *= RealT(1) / RealT(bondtri_horizontal);
-    Contract(&ham_nn_, {}, &id, {}, &extend_ham_nn_vertical);
-    extend_ham_nn_vertical *= RealT(1) / RealT(bondtri_vertical);
+    Contract(&id, {}, &ham_nn_, {}, &tri_ham_nn_1);
+    Contract(&ham_nn_, {}, &id, {}, &tri_ham_nn_2);
+    size_t hor_bond_tri_num = 4; // Number of triangle shared the horizontal NN bond
+    size_t ver_bond_tri_num = 4; // Number of triangle shared the vertical NN bond
+    if (!is_pbc) {
+      switch (triposition) {
+        case UpperLeft: {
+          if(site_b[0] == 0) hor_bond_tri_num = 2;
+          if(site_b[1] == 0) ver_bond_tri_num = 2;
+          hor_ham_nn = tri_ham_nn_2 * (RealT(1) / RealT(hor_bond_tri_num));
+          ver_ham_nn = tri_ham_nn_1 * (RealT(1) / RealT(ver_bond_tri_num));
+        }
+        case UpperRight: {
+          if(site_b[0] == 0) hor_bond_tri_num = 2;
+          if(site_b[1] == this->lx_ - 1) ver_bond_tri_num = 2;
+          hor_ham_nn = tri_ham_nn_2 * (RealT(1) / RealT(hor_bond_tri_num));
+          ver_ham_nn = tri_ham_nn_1 * (RealT(1) / RealT(ver_bond_tri_num));
+        }
+        case LowerLeft: {
+          if(site_b[0] == this->ly_ - 1) hor_bond_tri_num = 2;
+          if(site_b[1] == 0) ver_bond_tri_num = 2;
+          hor_ham_nn = tri_ham_nn_1 * (RealT(1) / RealT(hor_bond_tri_num));
+          ver_ham_nn = tri_ham_nn_2 * (RealT(1) / RealT(ver_bond_tri_num));
+        }
+        case LowerRight: {
+          if(site_b[0] == this->ly_ - 1) hor_bond_tri_num = 2;
+          if(site_b[1] == this->lx_ - 1) ver_bond_tri_num = 2;
+          hor_ham_nn = tri_ham_nn_1 * (RealT(1) / RealT(hor_bond_tri_num));
+          ver_ham_nn = tri_ham_nn_2 * (RealT(1) / RealT(ver_bond_tri_num));
+        }
+      }
+    }
 
      // on-site term
     if (ham_on_site_terms_(0, 0) == nullptr || ham_on_site_terms_(0, 0)->IsDefault()) {
-      return extend_ham_nnn + extend_ham_nn_horizontal + extend_ham_nn_vertical;
+      return tri_ham_nnn + hor_ham_nn + ver_ham_nn;
     } else {
       Tensor term1, term2, term3;
-      Tensor extend_on_site1, extend_on_site2, extend_on_site3;
+      Tensor tri_on_site1, tri_on_site2, tri_on_site3;
 
-      std::vector<size_t> site_share_tri(3, 6); // Number of triangle shared the site
-      for (size_t i = 0; i < tri_site.size(); i++) {
-        const SiteIdx &site = tri_site[i];
-        if(site[0] == 0 && site[1] > 0 && site[1] < this->lx_ - 1) 
-          site_share_tri[i] = 2; // first row
-        else if(site[1] == 0 && site[0] > 0 && site[0] < this->ly_ - 1) 
-          site_share_tri[i] = 3; // first column
-        else if(site[1] == this->lx_ - 1 && site[0] > 0 && site[0] < this->ly_ - 1) 
-          site_share_tri[i] = 3; // last column
-        else if(site[0] == 0 && (site[1] == 0 || site[1] == this->lx_ - 1))
-          site_share_tri[i] = 1; // corner site on the first row
-        else if(site[0] == this->ly_ - 1 && (site[1] == 0 || site[1] == this->lx_ - 1))
-          site_share_tri[i] = 2; // corner site on the last row
+      std::vector<size_t> site_tri_num(3, 12); // Number of triangle shared the site
+      if (!is_pbc) {
+        for (size_t i = 0; i < tri_site.size(); i++) {
+          const SiteIdx &site = tri_site[i];
+          if(site[0] == 0 && site[1] > 0 && site[1] < this->lx_ - 1) 
+            site_tri_num[i] = 6; // first row
+          else if(site[0] == this->ly_ - 1 && site[1] > 0 && site[1] < this->lx_ - 1) 
+            site_tri_num[i] = 6; // last row
+          else if(site[1] == 0 && site[0] > 0 && site[0] < this->ly_ - 1) 
+            site_tri_num[i] = 6; // first column
+          else if(site[1] == this->lx_ - 1 && site[0] > 0 && site[0] < this->ly_ - 1) 
+            site_tri_num[i] = 6; // last column
+          else if(site[0] == 0 && (site[1] == 0 || site[1] == this->lx_ - 1))
+            site_tri_num[i] = 3; // corner site on the first row
+          else if(site[0] == this->ly_ - 1 && (site[1] == 0 || site[1] == this->lx_ - 1))
+            site_tri_num[i] = 3; // corner site on the last row
+        }
       }
 
       // site A
       const Tensor & on_site_term1 = ham_on_site_terms_({tri_site[0][0], tri_site[0][1]});
       Contract(&on_site_term1, {}, &id, {}, &term1);
-      Contract(&term1, {}, &id, {}, &extend_on_site1);
-      extend_on_site1 *=  RealT(1) / RealT(site_share_tri[0]);
+      Contract(&term1, {}, &id, {}, &tri_on_site1);
+      tri_on_site1 *=  RealT(1) / RealT(site_tri_num[0]);
       // site B
       const Tensor & on_site_term2 = ham_on_site_terms_({tri_site[1][0], tri_site[1][1]});
       Contract(&id, {}, &on_site_term2, {}, &term2);
-      Contract(&term2, {}, &id, {}, &extend_on_site2);
-      extend_on_site2 *=  RealT(1) / RealT(site_share_tri[1]);
+      Contract(&term2, {}, &id, {}, &tri_on_site2);
+      tri_on_site2 *=  RealT(1) / RealT(site_tri_num[1]);
       // site C
       const Tensor & on_site_term3 = ham_on_site_terms_({tri_site[2][0], tri_site[2][1]});
       Contract(&id, {}, &id, {}, &term3);
-      Contract(&term3, {}, &on_site_term3, {}, &extend_on_site3);
-      extend_on_site3 *= RealT(1) / RealT(site_share_tri[2]);
+      Contract(&term3, {}, &on_site_term3, {}, &tri_on_site3);
+      tri_on_site3 *= RealT(1) / RealT(site_tri_num[2]);
 
-      return extend_ham_nnn + extend_ham_nn_horizontal + extend_ham_nn_vertical
-          + extend_on_site1 + extend_on_site2 + extend_on_site3;
+      return tri_ham_nnn + hor_ham_nn + ver_ham_nn
+          + tri_on_site1 + tri_on_site2 + tri_on_site3;
     }
   }
 
-  Tensor ConstructEvolveOperator(const SiteIdx &upper_site, const size_t leftright) const {
-    return TaylorExpMatrix(RealT(this->update_para.tau), ConstructTriHamiltonian(upper_site, leftright));
+  Tensor ConstructEvolveOperator(const SiteIdx &site_b, const TriProjPOSITION triposition) const {
+    return TaylorExpMatrix(RealT(this->update_para.tau), ConstructTriHamiltonian(site_b, triposition));
   }
 
   RealT SimpleUpdateSweep_(void) override;
@@ -196,27 +268,37 @@ class SquareLatticeNNNSimpleUpdateExecutor : public SimpleUpdateExecutor<TenElem
   Tensor ham_nnn_;  // uniform NNN interaction
   TenMatrix<Tensor> ham_on_site_terms_;  // on-site terms
 
+  TenMatrix<Tensor> ham_upperright_tri_;
+  TenMatrix<Tensor> ham_upperleft_tri_;
   TenMatrix<Tensor> ham_lowerright_tri_;
   TenMatrix<Tensor> ham_lowerleft_tri_;
   // A-B-C 3-site, A-B and B-C are NN connect, A-C is NNN connect
   // A-B or B-C has half of J1 interaction, A-C has a J2 interaction
   // A, B and C also have on-site interaction
 
-  Tensor evolve_gate_nn_;
+  TenMatrix<Tensor> evolve_gate_upperright_tri_;
+  TenMatrix<Tensor> evolve_gate_upperleft_tri_;
   TenMatrix<Tensor> evolve_gate_lowerright_tri_;
   TenMatrix<Tensor> evolve_gate_lowerleft_tri_;
 };
 
 template<typename TenElemT, typename QNT>
 void SquareLatticeNNNSimpleUpdateExecutor<TenElemT, QNT>::SetEvolveGate_(void) {
-  evolve_gate_nn_ = TaylorExpMatrix(RealT(this->update_para.tau), ham_nn_);
+  const bool is_pbc = (this->peps_.GetBoundaryCondition() == BoundaryCondition::Periodic);
+  const size_t hor_bond_limit = is_pbc ? this->lx_ : this->lx_ - 1;
+  const size_t ver_bond_limit = is_pbc ? this->ly_ : this->ly_ - 1;
+
   
-  for (size_t col = 0; col < this->lx_ - 1; col++) {
-    for (size_t row = 0; row < this->ly_ - 1; row++) {
-      ham_lowerright_tri_({row, col + 1}) = ConstructTriHamiltonian({row, col + 1}, 1);
-      evolve_gate_lowerright_tri_({row, col + 1}) = ConstructEvolveOperator({row, col + 1}, 1);
-      ham_lowerleft_tri_({row, col}) = ConstructTriHamiltonian({row, col}, 0);
-      evolve_gate_lowerleft_tri_({row, col}) = ConstructEvolveOperator({row, col}, 0);
+  for (size_t col = 0; col < hor_bond_limit; col++) {
+    for (size_t row = 0; row < ver_bond_limit; row++) {
+      ham_upperleft_tri_({row, col}) = ConstructTriHamiltonian({row, col}, UpperLeft);
+      evolve_gate_upperleft_tri_({row, col}) = ConstructEvolveOperator({row, col}, UpperLeft);
+      ham_upperright_tri_({row, col}) = ConstructTriHamiltonian({row, (col + 1) % this->lx_}, UpperRight);
+      evolve_gate_upperright_tri_({row, col}) = ConstructEvolveOperator({row, (col + 1) % this->lx_}, UpperRight);
+      ham_lowerleft_tri_({row, col}) = ConstructTriHamiltonian({(row + 1) % this->ly_, col}, LowerLeft);
+      evolve_gate_lowerleft_tri_({row, col}) = ConstructEvolveOperator({(row + 1) % this->ly_, col}, LowerLeft);
+      ham_lowerright_tri_({row, col}) = ConstructTriHamiltonian({(row + 1) % this->ly_, (col + 1) % this->lx_}, LowerRight);
+      evolve_gate_lowerright_tri_({row, col}) = ConstructEvolveOperator({(row + 1) % this->ly_, (col + 1) % this->lx_}, LowerRight);
     }
   }
   
@@ -230,14 +312,18 @@ typename SquareLatticeNNNSimpleUpdateExecutor<TenElemT, QNT>::RealT SquareLattic
   RealT norm = 1.0;
   RealT max_trunc_err = 0.0;
 
-  for (size_t col = 0; col < this->lx_ - 1; col++) {  //first row
-    ProjectionRes<TenElemT>
-        proj_res = this->peps_.NearestNeighborSiteProject(evolve_gate_nn_, {0, col}, HORIZONTAL, para, ham_nn_);
-    e0 += proj_res.e_loc.value();
-    norm *= proj_res.norm;
-    max_trunc_err = std::max(max_trunc_err, proj_res.trunc_err);
-    //e0 += -std::log(proj_res.norm) / this->update_para.tau;
-  }
+  const bool is_pbc = (this->peps_.GetBoundaryCondition() == BoundaryCondition::Periodic);
+  const size_t hor_bond_limit = is_pbc ? this->lx_ : this->lx_ - 1;
+  const size_t ver_bond_limit = is_pbc ? this->ly_ : this->ly_ - 1;
+
+  // for (size_t col = 0; col < this->lx_ - 1; col++) {  //first row
+  //   ProjectionRes<TenElemT>
+  //       proj_res = this->peps_.NearestNeighborSiteProject(evolve_gate_nn_, {0, col}, HORIZONTAL, para, ham_nn_);
+  //   e0 += proj_res.e_loc.value();
+  //   norm *= proj_res.norm;
+  //   max_trunc_err = std::max(max_trunc_err, proj_res.trunc_err);
+  //   //e0 += -std::log(proj_res.norm) / this->update_para.tau;
+  // }
 
   // for (size_t row = 0; row < this->ly_ - 1; row++) {  // first and last column
   //   ProjectionRes<TenElemT>
@@ -247,21 +333,43 @@ typename SquareLatticeNNNSimpleUpdateExecutor<TenElemT, QNT>::RealT SquareLattic
   //   e0 += -std::log(proj_res.norm) / this->update_para.tau;
   // }
 
-  for (size_t col = 0; col < this->lx_ - 1; col++) {
-    for (size_t row = 0; row < this->ly_ - 1; row++) {
+  for (size_t col = 0; col < hor_bond_limit; col++) {
+    for (size_t row = 0; row < ver_bond_limit; row++) {
       ProjectionRes<TenElemT>
-          proj_res1 = this->peps_.LowerRightTriangleProject(evolve_gate_lowerright_tri_({row, col + 1}), {row, col + 1}, para, ham_lowerright_tri_({row, col + 1}));
-      //e0 += -std::log(proj_res.norm) / this->update_para.tau;
+          proj_res1 = this->peps_.UpperRightTriangleProject(evolve_gate_upperright_tri_({row, col}), 
+                                                           {row, (col + 1) % this->lx_}, 
+                                                            para, 
+                                                            ham_upperright_tri_({row, col}));
       e0 += proj_res1.e_loc.value();
       norm *= proj_res1.norm;
       max_trunc_err = std::max(max_trunc_err, proj_res1.trunc_err);
-
+      
       ProjectionRes<TenElemT>
-          proj_res2 = this->peps_.LowerLeftTriangleProject(evolve_gate_lowerleft_tri_({row, col}), {row, col}, para, ham_lowerleft_tri_({row, col}));
-      //e0 += -std::log(norm) / this->update_para.tau;
+          proj_res2 = this->peps_.UpperLeftTriangleProject(evolve_gate_upperleft_tri_({row, col}), 
+                                                          {row, col}, 
+                                                           para, 
+                                                           ham_upperleft_tri_({row, col}));
       e0 += proj_res2.e_loc.value();
       norm *= proj_res2.norm;
       max_trunc_err = std::max(max_trunc_err, proj_res2.trunc_err);
+
+      ProjectionRes<TenElemT>
+          proj_res3 = this->peps_.LowerRightTriangleProject(evolve_gate_lowerright_tri_({row, col}), 
+                                                           {row, (col + 1) % this->lx_}, 
+                                                            para, 
+                                                            ham_lowerright_tri_({row, col}));
+      e0 += proj_res3.e_loc.value();
+      norm *= proj_res3.norm;
+      max_trunc_err = std::max(max_trunc_err, proj_res3.trunc_err);
+
+      ProjectionRes<TenElemT>
+          proj_res4 = this->peps_.LowerLeftTriangleProject(evolve_gate_lowerleft_tri_({row, col}), 
+                                                          {row, col}, 
+                                                           para, 
+                                                           ham_lowerleft_tri_({row, col}));
+      e0 += proj_res4.e_loc.value();
+      norm *= proj_res4.norm;
+      max_trunc_err = std::max(max_trunc_err, proj_res4.trunc_err);
     }
   }
 

--- a/include/qlpeps/algorithm/simple_update/square_lattice_nnn_simple_update.h
+++ b/include/qlpeps/algorithm/simple_update/square_lattice_nnn_simple_update.h
@@ -105,11 +105,19 @@ class SquareLatticeNNNSimpleUpdateExecutor : public SimpleUpdateExecutor<TenElem
 
   /**
    * @return h_{ABC} = ham_{nnn}^A \otimes id \otimes ham_{nnn}^C
-   *                 + id \otimes ham_{nn}^{BC} / bondtri\_horizontal
-   *                 + ham_{nn}^{AB} \otimes id / bondtri\_vertical
-   *                 + ham\_on\_site\_terms_A \otimes id \otimes id / site\_share\_tri_A
-   *                 + id \otimes ham\_on\_site\_terms_B \otimes id / site\_share\_tri_B
-   *                 + id \otimes id \otimes ham\_on\_site\_terms_C / site\_share\_tri_C
+   *                 + id \otimes ham_{nn}^{BC} / ver\_bond\_tri\_num
+   *                 + ham_{nn}^{AB} \otimes id / hor\_bond\_tri\_num
+   *                 + ham\_on\_site\_terms_A \otimes id \otimes id / site\_tri\_num\_A
+   *                 + id \otimes ham\_on\_site\_terms_B \otimes id / site\_tri\_num\_B
+   *                 + id \otimes id \otimes ham\_on\_site\_terms_C / site\_tri\_num\_C
+   *        (For UpperLeft and UpperRight)
+   *        h_{ABC} = ham_{nnn}^A \otimes id \otimes ham_{nnn}^C
+   *                 + id \otimes ham_{nn}^{BC} / hor\_bond\_tri\_num
+   *                 + ham_{nn}^{AB} \otimes id / ver\_bond\_tri\_num
+   *                 + ham\_on\_site\_terms_A \otimes id \otimes id / site\_tri\_num\_A
+   *                 + id \otimes ham\_on\_site\_terms_B \otimes id / site\_tri\_num\_B
+   *                 + id \otimes id \otimes ham\_on\_site\_terms_C / site\_tri\_num\_C
+   *        (For LowerLeft and LowerRight)
    *
    *         UpperLeft                      UpperRight                     LowerLeft                      LowerRight
    *      |             |                |             |                |             |                |             |

--- a/include/qlpeps/algorithm/simple_update/square_lattice_nnn_simple_update.h
+++ b/include/qlpeps/algorithm/simple_update/square_lattice_nnn_simple_update.h
@@ -348,10 +348,23 @@ typename SquareLatticeNNNSimpleUpdateExecutor<TenElemT, QNT>::RealT SquareLattic
   for (size_t col = 0; col < hor_bond_limit; col++) {
     for (size_t row = 0; row < ver_bond_limit; row++) {
       ProjectionRes<TenElemT>
-          proj_res3 = this->peps_.LowerRightTriangleProject(evolve_gate_lowerright_tri_({row, col}), 
+          proj_res2 = this->peps_.LowerRightTriangleProject(evolve_gate_lowerright_tri_({row, col}), 
                                                            {row, (col + 1) % this->peps_.lambda_horiz.cols()}, 
                                                             para, 
                                                             ham_lowerright_tri_({row, col}));
+      e0 += proj_res2.e_loc.value();
+      norm *= proj_res2.norm;
+      max_trunc_err = std::max(max_trunc_err, proj_res2.trunc_err);
+    }
+  }
+
+  for (size_t col = 0; col < hor_bond_limit; col++) {
+    for (size_t row = 0; row < ver_bond_limit; row++) {
+      ProjectionRes<TenElemT>
+          proj_res3 = this->peps_.LowerLeftTriangleProject(evolve_gate_lowerleft_tri_({row, col}), 
+                                                          {row, col}, 
+                                                           para, 
+                                                           ham_lowerleft_tri_({row, col}));
       e0 += proj_res3.e_loc.value();
       norm *= proj_res3.norm;
       max_trunc_err = std::max(max_trunc_err, proj_res3.trunc_err);
@@ -361,26 +374,13 @@ typename SquareLatticeNNNSimpleUpdateExecutor<TenElemT, QNT>::RealT SquareLattic
   for (size_t col = 0; col < hor_bond_limit; col++) {
     for (size_t row = 0; row < ver_bond_limit; row++) {
       ProjectionRes<TenElemT>
-          proj_res4 = this->peps_.LowerLeftTriangleProject(evolve_gate_lowerleft_tri_({row, col}), 
-                                                          {row, col}, 
-                                                           para, 
-                                                           ham_lowerleft_tri_({row, col}));
-      e0 += proj_res4.e_loc.value();
-      norm *= proj_res4.norm;
-      max_trunc_err = std::max(max_trunc_err, proj_res4.trunc_err);
-    }
-  }
-
-  for (size_t col = 0; col < hor_bond_limit; col++) {
-    for (size_t row = 0; row < ver_bond_limit; row++) {
-      ProjectionRes<TenElemT>
-          proj_res2 = this->peps_.UpperLeftTriangleProject(evolve_gate_upperleft_tri_({row, col}), 
+          proj_res4 = this->peps_.UpperLeftTriangleProject(evolve_gate_upperleft_tri_({row, col}), 
                                                           {row, col}, 
                                                            para, 
                                                            ham_upperleft_tri_({row, col}));
-      e0 += proj_res2.e_loc.value();
-      norm *= proj_res2.norm;
-      max_trunc_err = std::max(max_trunc_err, proj_res2.trunc_err);
+      e0 += proj_res4.e_loc.value();
+      norm *= proj_res4.norm;
+      max_trunc_err = std::max(max_trunc_err, proj_res4.trunc_err);
     }
   }
 

--- a/include/qlpeps/two_dim_tn/peps/square_lattice_peps.h
+++ b/include/qlpeps/two_dim_tn/peps/square_lattice_peps.h
@@ -298,15 +298,17 @@ class SquareLatticePEPS {
   );
 
   ProjectionRes<TenElemT> LowerRightTriangleProject(
-      const TenT &,
-      const SiteIdx &,
-      const SimpleUpdateTruncatePara &tunc_para
+      const TenT &gate_ten,
+      const SiteIdx &upper_site,
+      const SimpleUpdateTruncatePara &tunc_para,
+      const TenT &ham_ten = TenT()
   );
 
-  RealT LowerLeftTriangleProject(
+  ProjectionRes<TenElemT> LowerLeftTriangleProject(
       const TenT &gate_ten,
       const SiteIdx &upper_left_site,
-      const SimpleUpdateTruncatePara &trunc_para
+      const SimpleUpdateTruncatePara &trunc_para,
+      const TenT &ham_ten = TenT()
   );
 
   ///< fix the convenction of index direction: from left to right, from up to down. For the convention of index direction may be broken after loop update.

--- a/include/qlpeps/two_dim_tn/peps/square_lattice_peps.h
+++ b/include/qlpeps/two_dim_tn/peps/square_lattice_peps.h
@@ -291,10 +291,18 @@ class SquareLatticePEPS {
       const SimpleUpdateTruncatePara &trunc_para
   );
 
+      ProjectionRes<TenElemT> UpperRightTriangleProject(
+      const TenT &gate_ten,
+      const SiteIdx &right_upper_site,
+      const SimpleUpdateTruncatePara &trunc_para,
+      const TenT &ham_ten = TenT()
+  );
+
   ProjectionRes<TenElemT> UpperLeftTriangleProject(
-      const TenT &,
-      const SiteIdx &,
-      const SimpleUpdateTruncatePara &
+      const TenT &gate_ten,
+      const SiteIdx &left_upper_site,
+      const SimpleUpdateTruncatePara &trunc_para,
+      const TenT &ham_ten = TenT()
   );
 
   ProjectionRes<TenElemT> LowerRightTriangleProject(

--- a/include/qlpeps/two_dim_tn/peps/square_lattice_peps_projection_impl.h
+++ b/include/qlpeps/two_dim_tn/peps/square_lattice_peps_projection_impl.h
@@ -326,10 +326,10 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
   qlten::SVD(tmp_ten + 5, 5, tmp_ten[5].Div(),
              trunc_para.trunc_err, trunc_para.D_min, trunc_para.D_max,
              &u1, &s1, &vt1, &actual_trunc_err1, &actual_D1);
-  norm *= s1.QuasiNormalize();
+  //norm *= s1.QuasiNormalize();
   lambda_horiz({right_upper_site}) = s1;
   lambda_horiz({right_upper_site}).Transpose({1, 0});
-  tmp_ten[6] = QTenSplitOutLambdas_(q1, left_site, RIGHT, trunc_para.trunc_err);
+  tmp_ten[6] = QTenSplitOutLambdas_(q1, left_site, RIGHT, trunc_para.inv_tol);
   Gamma(left_site) = TenT();
   Contract<TenElemT, QNT, false, false>(tmp_ten[6], vt1, 0, 2, 1, Gamma(left_site));
   Gamma(left_site).Transpose({1, 2, 3, 0, 4});
@@ -343,18 +343,18 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
    *       |
    *       4
    */
-  norm *= s2.QuasiNormalize();
+  //norm *= s2.QuasiNormalize();
   lambda_vert({lower_site}) = s2;
   lambda_vert({lower_site}).Transpose({1, 0});
-  tmp_ten[8] = QTenSplitOutLambdas_(q0, lower_site, UP, trunc_para.trunc_err);
+  tmp_ten[8] = QTenSplitOutLambdas_(q0, lower_site, UP, trunc_para.inv_tol);
   Gamma(lower_site) = TenT();
   Contract<TenElemT, QNT, false, false>(tmp_ten[8], u2, 1, 1, 1, Gamma(lower_site));
   Gamma(lower_site).Transpose({2, 1, 0, 3, 4});
-  auto inv_lam = DiagMatInv(s1, trunc_para.trunc_err);
+  auto inv_lam = DiagMatInv(s1, trunc_para.inv_tol);
   Contract(&vt2, {4}, &inv_lam, {0}, &tmp_ten[9]);
-  inv_lam = DiagMatInv(GetLambdaVertNorth(row, col), trunc_para.trunc_err);
+  inv_lam = DiagMatInv(GetLambdaVertNorth(row, col), trunc_para.inv_tol);
   Contract<TenElemT, QNT, false, false>(tmp_ten[9], inv_lam, 2, 1, 1, tmp_ten[10]);
-  inv_lam = DiagMatInv(GetLambdaHorizEast(row, col), trunc_para.trunc_err);
+  inv_lam = DiagMatInv(GetLambdaHorizEast(row, col), trunc_para.inv_tol);
   Gamma({right_upper_site}) = TenT();
   Contract<TenElemT, QNT, false, true>(tmp_ten[10], inv_lam, 3, 0, 1, Gamma({right_upper_site}));
   Gamma({right_upper_site}).Transpose({2, 3, 4, 0, 1});
@@ -433,7 +433,7 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
   qlten::SVD(tmp_ten + 5, 5, tmp_ten[5].Div(),
              trunc_para.trunc_err, trunc_para.D_min, trunc_para.D_max,
              &u1, &s1, &vt1, &actual_trunc_err1, &actual_D1);
-  norm *= s1.QuasiNormalize();
+  //norm *= s1.QuasiNormalize();
   lambda_vert({lower_site}) = s1;
   tmp_ten[6] = QTenSplitOutLambdas_(q1, lower_site, UP, trunc_para.inv_tol);
 
@@ -451,7 +451,7 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
  *      |
  *      4
  */
-  norm *= s2.QuasiNormalize();
+  //norm *= s2.QuasiNormalize();
   lambda_horiz({right_site}) = s2;
   lambda_horiz({right_site}).Transpose({1, 0});
   tmp_ten[8] = QTenSplitOutLambdas_(q0, right_site, LEFT, trunc_para.inv_tol);
@@ -541,7 +541,7 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
   qlten::SVD(tmp_ten + 5, 5, tmp_ten[5].Div(),
              trunc_para.trunc_err, trunc_para.D_min, trunc_para.D_max,
              &u1, &s1, &vt1, &actual_trunc_err1, &actual_D1);
-  norm *= s1.QuasiNormalize();
+  //norm *= s1.QuasiNormalize();
   lambda_vert({right_down_site}) = s1;
   lambda_vert({right_down_site}).Transpose({1, 0});
   tmp_ten[6] = QTenSplitOutLambdas_(q1, upper_site, DOWN, trunc_para.inv_tol);
@@ -559,7 +559,7 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
    *       |
    *       1
    */
-  norm *= s2.QuasiNormalize();
+  //norm *= s2.QuasiNormalize();
   lambda_horiz({right_down_site}) = s2;
   tmp_ten[8] = QTenSplitOutLambdas_(q0, left_site, RIGHT, trunc_para.inv_tol);
   Gamma(left_site) = TenT();
@@ -654,7 +654,7 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT, QNT>::LowerLeftTriangleProje
   qlten::SVD(tmp_ten + 5, 5, tmp_ten[5].Div(),
              trunc_para.trunc_err, trunc_para.D_min, trunc_para.D_max,
              &u1, &s1, &vt1, &actual_trunc_err1, &actual_D1);
-  norm *= s1.QuasiNormalize();
+  //norm *= s1.QuasiNormalize();
   lambda_horiz({lower_right_site}) = s1;
   tmp_ten[6] = QTenSplitOutLambdas_(q1, lower_right_site, LEFT, trunc_para.inv_tol);
   /**
@@ -681,7 +681,7 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT, QNT>::LowerLeftTriangleProje
 #ifndef NDEBUG
   assert(vt2.GetIndex(1) == index_2.back());
 #endif
-  norm *= s2.QuasiNormalize();
+  //norm *= s2.QuasiNormalize();
   lambda_vert({lower_left_site}) = s2;
   tmp_ten[8] = QTenSplitOutLambdas_(q0, upper_left_site, DOWN, trunc_para.inv_tol);
 /*

--- a/include/qlpeps/two_dim_tn/peps/square_lattice_peps_projection_impl.h
+++ b/include/qlpeps/two_dim_tn/peps/square_lattice_peps_projection_impl.h
@@ -326,7 +326,7 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
   qlten::SVD(tmp_ten + 5, 5, tmp_ten[5].Div(),
              trunc_para.trunc_err, trunc_para.D_min, trunc_para.D_max,
              &u1, &s1, &vt1, &actual_trunc_err1, &actual_D1);
-  //norm *= s1.QuasiNormalize();
+  norm *= s1.QuasiNormalize();
   lambda_horiz({right_upper_site}) = s1;
   lambda_horiz({right_upper_site}).Transpose({1, 0});
   tmp_ten[6] = QTenSplitOutLambdas_(q1, left_site, RIGHT, trunc_para.trunc_err);
@@ -343,7 +343,7 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
    *       |
    *       4
    */
-  //norm *= s2.QuasiNormalize();
+  norm *= s2.QuasiNormalize();
   lambda_vert({lower_site}) = s2;
   lambda_vert({lower_site}).Transpose({1, 0});
   tmp_ten[8] = QTenSplitOutLambdas_(q0, lower_site, UP, trunc_para.trunc_err);
@@ -351,7 +351,6 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
   Contract<TenElemT, QNT, false, false>(tmp_ten[8], u2, 1, 1, 1, Gamma(lower_site));
   Gamma(lower_site).Transpose({2, 1, 0, 3, 4});
   auto inv_lam = DiagMatInv(s1, trunc_para.trunc_err);
-  //Contract(&vt2, {3}, &inv_lam, {0}, &tmp_ten[9]);
   Contract(&vt2, {4}, &inv_lam, {0}, &tmp_ten[9]);
   inv_lam = DiagMatInv(GetLambdaVertNorth(row, col), trunc_para.trunc_err);
   Contract<TenElemT, QNT, false, false>(tmp_ten[9], inv_lam, 2, 1, 1, tmp_ten[10]);
@@ -434,7 +433,7 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
   qlten::SVD(tmp_ten + 5, 5, tmp_ten[5].Div(),
              trunc_para.trunc_err, trunc_para.D_min, trunc_para.D_max,
              &u1, &s1, &vt1, &actual_trunc_err1, &actual_D1);
-  //norm *= s1.QuasiNormalize();
+  norm *= s1.QuasiNormalize();
   lambda_vert({lower_site}) = s1;
   tmp_ten[6] = QTenSplitOutLambdas_(q1, lower_site, UP, trunc_para.inv_tol);
 
@@ -452,7 +451,7 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
  *      |
  *      4
  */
-  //norm *= s2.QuasiNormalize();
+  norm *= s2.QuasiNormalize();
   lambda_horiz({right_site}) = s2;
   lambda_horiz({right_site}).Transpose({1, 0});
   tmp_ten[8] = QTenSplitOutLambdas_(q0, right_site, LEFT, trunc_para.inv_tol);
@@ -542,7 +541,7 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
   qlten::SVD(tmp_ten + 5, 5, tmp_ten[5].Div(),
              trunc_para.trunc_err, trunc_para.D_min, trunc_para.D_max,
              &u1, &s1, &vt1, &actual_trunc_err1, &actual_D1);
-  //norm *= s1.QuasiNormalize();
+  norm *= s1.QuasiNormalize();
   lambda_vert({right_down_site}) = s1;
   lambda_vert({right_down_site}).Transpose({1, 0});
   tmp_ten[6] = QTenSplitOutLambdas_(q1, upper_site, DOWN, trunc_para.inv_tol);
@@ -560,7 +559,7 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
    *       |
    *       1
    */
-  //norm *= s2.QuasiNormalize();
+  norm *= s2.QuasiNormalize();
   lambda_horiz({right_down_site}) = s2;
   tmp_ten[8] = QTenSplitOutLambdas_(q0, left_site, RIGHT, trunc_para.inv_tol);
   Gamma(left_site) = TenT();
@@ -655,6 +654,7 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT, QNT>::LowerLeftTriangleProje
   qlten::SVD(tmp_ten + 5, 5, tmp_ten[5].Div(),
              trunc_para.trunc_err, trunc_para.D_min, trunc_para.D_max,
              &u1, &s1, &vt1, &actual_trunc_err1, &actual_D1);
+  norm *= s1.QuasiNormalize();
   lambda_horiz({lower_right_site}) = s1;
   tmp_ten[6] = QTenSplitOutLambdas_(q1, lower_right_site, LEFT, trunc_para.inv_tol);
   /**
@@ -681,7 +681,7 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT, QNT>::LowerLeftTriangleProje
 #ifndef NDEBUG
   assert(vt2.GetIndex(1) == index_2.back());
 #endif
-  //norm *= s2.QuasiNormalize();
+  norm *= s2.QuasiNormalize();
   lambda_vert({lower_left_site}) = s2;
   tmp_ten[8] = QTenSplitOutLambdas_(q0, upper_left_site, DOWN, trunc_para.inv_tol);
 /*

--- a/include/qlpeps/two_dim_tn/peps/square_lattice_peps_projection_impl.h
+++ b/include/qlpeps/two_dim_tn/peps/square_lattice_peps_projection_impl.h
@@ -353,9 +353,9 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
   auto inv_lam = DiagMatInv(s1, trunc_para.trunc_err);
   //Contract(&vt2, {3}, &inv_lam, {0}, &tmp_ten[9]);
   Contract(&vt2, {4}, &inv_lam, {0}, &tmp_ten[9]);
-  inv_lam = DiagMatInv(lambda_vert({right_upper_site}), trunc_para.trunc_err);
+  inv_lam = DiagMatInv(GetLambdaVertNorth(row, col), trunc_para.trunc_err);
   Contract<TenElemT, QNT, false, false>(tmp_ten[9], inv_lam, 2, 1, 1, tmp_ten[10]);
-  inv_lam = DiagMatInv(lambda_horiz({row, (col + 1) % lambda_horiz.cols()}), trunc_para.trunc_err);
+  inv_lam = DiagMatInv(GetLambdaHorizEast(row, col), trunc_para.trunc_err);
   Gamma({right_upper_site}) = TenT();
   Contract<TenElemT, QNT, false, true>(tmp_ten[10], inv_lam, 3, 0, 1, Gamma({right_upper_site}));
   Gamma({right_upper_site}).Transpose({2, 3, 4, 0, 1});
@@ -462,9 +462,9 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
 
   auto inv_lam = DiagMatInv(s1, trunc_para.inv_tol);
   Contract(&vt2, {4}, &inv_lam, {0}, &tmp_ten[9]);
-  inv_lam = DiagMatInv(lambda_vert({row, col}), trunc_para.inv_tol);
+  inv_lam = DiagMatInv(GetLambdaVertNorth(row, col), trunc_para.inv_tol);
   Contract<TenElemT, QNT, false, true>(tmp_ten[9], inv_lam, 2, 1, 1, tmp_ten[10]);
-  inv_lam = DiagMatInv(lambda_horiz({row, col}), trunc_para.inv_tol);
+  inv_lam = DiagMatInv(GetLambdaHorizWest(row, col), trunc_para.inv_tol);
   Gamma({left_upper_site}) = TenT();
   Contract<TenElemT, QNT, false, true>(tmp_ten[10], inv_lam, 0, 1, 1, Gamma({left_upper_site}));
   Gamma({left_upper_site}).Transpose({4, 0, 1, 3, 2});
@@ -568,9 +568,9 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
   Gamma(left_site).Transpose({1, 2, 3, 0, 4});
   auto inv_lam = DiagMatInv(s1, trunc_para.inv_tol);
   Contract(&vt2, {4}, &inv_lam, {0}, &tmp_ten[9]);
-  inv_lam = DiagMatInv(lambda_vert({(row + 2) % lambda_vert.rows(), col}), trunc_para.inv_tol);
+  inv_lam = DiagMatInv(GetLambdaVertSouth(lower_row, col), trunc_para.inv_tol);
   Contract<TenElemT, QNT, false, true>(tmp_ten[9], inv_lam, 1, 0, 1, tmp_ten[10]);
-  inv_lam = DiagMatInv(lambda_horiz({(row + 1) % lambda_horiz.rows(), (col + 1) % lambda_horiz.cols()}), trunc_para.inv_tol);
+  inv_lam = DiagMatInv(GetLambdaHorizEast(lower_row, col), trunc_para.inv_tol);
   Gamma({right_down_site}) = TenT();
   Contract<TenElemT, QNT, false, true>(tmp_ten[10], inv_lam, 0, 0, 1, Gamma({right_down_site}));
   Gamma({right_down_site}).Transpose({2, 3, 4, 1, 0});
@@ -697,9 +697,9 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT, QNT>::LowerLeftTriangleProje
 
   auto inv_lam = DiagMatInv(s1, trunc_para.inv_tol);
   Contract(&vt2, {4}, &inv_lam, {0}, &tmp_ten[9]);
-  inv_lam = DiagMatInv(lambda_vert({(row + 2) % lambda_vert.rows(), col}), trunc_para.inv_tol);
+  inv_lam = DiagMatInv(GetLambdaVertSouth(lower_row, col), trunc_para.inv_tol);
   Contract<TenElemT, QNT, false, true>(tmp_ten[9], inv_lam, 3, 0, 1, tmp_ten[10]);
-  inv_lam = DiagMatInv(lambda_horiz({(row + 1) % lambda_horiz.rows(), col}), trunc_para.inv_tol);
+  inv_lam = DiagMatInv(GetLambdaHorizWest(lower_row, col), trunc_para.inv_tol);
   Gamma({lower_left_site}) = TenT();
   Contract<TenElemT, QNT, false, false>(tmp_ten[10], inv_lam, 3, 1, 1, Gamma({lower_left_site}));
   Gamma({lower_left_site}).Transpose({4, 0, 1, 2, 3});

--- a/include/qlpeps/two_dim_tn/peps/square_lattice_peps_projection_impl.h
+++ b/include/qlpeps/two_dim_tn/peps/square_lattice_peps_projection_impl.h
@@ -40,6 +40,24 @@ TenElemT EvaluateTwoSiteEnergy(const QLTensor<TenElemT, QNT> &ham,
 }
 
 template<typename TenElemT, typename QNT>
+TenElemT EvaluateThreeSiteEnergy(const QLTensor<TenElemT, QNT> &ham,
+                                 const QLTensor<TenElemT, QNT> &state) {
+  using TenT = QLTensor<TenElemT, QNT>;
+  TenT temp, temp_scale;
+  Contract(&state, {4, 5, 6}, &ham, {0, 2, 4}, &temp); // physical index = 4,5,6
+  if (TenT::IsFermionic()) {
+    TenT state_dag = Dag(state);
+    state_dag.ActFermionPOps();
+    Contract(&temp, {0, 1, 2, 3, 4, 5, 6}, &state_dag, {0, 1, 2, 3, 4, 5, 6}, &temp_scale);
+    return temp_scale();
+  } else {// bosonic case
+    temp.Dag();
+    Contract(&temp, {0, 1, 2, 3, 4, 5, 6}, &state, {0, 1, 2, 3, 4, 5, 6}, &temp_scale);
+    return temp_scale();
+  }
+}
+
+template<typename TenElemT, typename QNT>
 ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT, QNT>::NearestNeighborSiteProject(const TenT &gate_ten,
                                                                                      const SiteIdx &site,
                                                                                      const BondOrientation &orientation,
@@ -363,27 +381,25 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
  */
 template<typename TenElemT, typename QNT>
 ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
-                                          QNT>::LowerRightTriangleProject(const SquareLatticePEPS::TenT &gate_ten,
+                                          QNT>::LowerRightTriangleProject(const TenT &gate_ten,
                                                                           const SiteIdx &upper_site,
-                                                                          const SimpleUpdateTruncatePara &trunc_para) {
+                                                                          const SimpleUpdateTruncatePara &trunc_para,
+                                                                          const TenT &ham) {
 #ifndef NDEBUG
   auto physical_index = Gamma(upper_site).GetIndex(4);
 #endif
   RealT norm = 1;
+  std::optional<TenElemT> e_loc;
   size_t row = upper_site[0], col = upper_site[1];
   size_t lower_row = (row + 1) % lambda_vert.rows();
   size_t left_col = (col + lambda_horiz.cols() - 1) % lambda_horiz.cols();
   SiteIdx left_site = {lower_row, left_col};
   SiteIdx right_down_site = {lower_row, col};
   TenT tmp_ten[11], q0, r0, q1, r1;
-  tmp_ten[0] = Eat3SurroundLambdas_(left_site, RIGHT);
-  QR(tmp_ten, 3, tmp_ten[0].Div(), &q0, &r0);
-  tmp_ten[1] = Eat3SurroundLambdas_(upper_site, DOWN);
-  QR(tmp_ten + 1, 3, tmp_ten[1].Div(), &q1, &r1);
-  tmp_ten[2] = EatSurroundLambdas_(right_down_site);
-  Contract<TenElemT, QNT, true, false>(r1, tmp_ten[2], 2, 4, 1, tmp_ten[3]);
-  Contract<TenElemT, QNT, false, false>(tmp_ten[3], r0, 3, 2, 1, tmp_ten[4]);
-  Contract(tmp_ten + 4, {3, 4, 6}, &gate_ten, {0, 1, 2}, tmp_ten + 5);
+  TenT u1, vt1, u2, vt2;
+  DTenT s1, s2;
+  RealT actual_trunc_err1, actual_trunc_err2;
+  size_t actual_D1, actual_D2;
   /**
    *  tmp_ten[5] is a rank-7 tensor
    *         2
@@ -392,15 +408,26 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
    *        |
    *        0
    */
+  tmp_ten[0] = Eat3SurroundLambdas_(left_site, RIGHT);
+  QR(tmp_ten, 3, tmp_ten[0].Div(), &q0, &r0);
+  tmp_ten[1] = Eat3SurroundLambdas_(upper_site, DOWN);
+  QR(tmp_ten + 1, 3, tmp_ten[1].Div(), &q1, &r1);
+  tmp_ten[2] = EatSurroundLambdas_(right_down_site);
+  Contract<TenElemT, QNT, true, false>(r1, tmp_ten[2], 2, 4, 1, tmp_ten[3]);
+  Contract<TenElemT, QNT, false, false>(tmp_ten[3], r0, 3, 2, 1, tmp_ten[4]);
+  Contract(tmp_ten + 4, {3, 4, 6}, &gate_ten, {0, 1, 2}, tmp_ten + 5);
+
+  norm *= tmp_ten[5].QuasiNormalize();
+  if (!ham.IsDefault()) { //estimate the local energy by local environment
+    const TenT *state = tmp_ten + 5;
+    e_loc = EvaluateThreeSiteEnergy(ham, *state);
+  }
   tmp_ten[5].Transpose({6, 3, 0, 1, 5, 4, 2});
-  TenT u1, vt1, u2, vt2;
-  DTenT s1, s2;
-  RealT trunc_err1, trunc_err2;
-  size_t D1, D2;
+  
   qlten::SVD(tmp_ten + 5, 5, tmp_ten[5].Div(),
              trunc_para.trunc_err, trunc_para.D_min, trunc_para.D_max,
-             &u1, &s1, &vt1, &trunc_err1, &D1);
-  norm *= s1.QuasiNormalize();
+             &u1, &s1, &vt1, &actual_trunc_err1, &actual_D1);
+  //norm *= s1.QuasiNormalize();
   lambda_vert({right_down_site}) = s1;
   lambda_vert({right_down_site}).Transpose({1, 0});
   tmp_ten[6] = QTenSplitOutLambdas_(q1, upper_site, DOWN, trunc_para.inv_tol);
@@ -410,7 +437,7 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
   Gamma(upper_site).Transpose({2, 3, 0, 1, 4});
   Contract(&u1, {5}, &s1, {0}, &tmp_ten[7]);
   qlten::SVD(tmp_ten + 7, 2, qn0_, trunc_para.trunc_err, trunc_para.D_min, trunc_para.D_max,
-             &u2, &s2, &vt2, &trunc_err2, &D2);
+             &u2, &s2, &vt2, &actual_trunc_err2, &actual_D2);
   /**
    *       4
    *       |
@@ -418,7 +445,7 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
    *       |
    *       1
    */
-  norm *= s2.QuasiNormalize();
+  //norm *= s2.QuasiNormalize();
   lambda_horiz({right_down_site}) = s2;
   tmp_ten[8] = QTenSplitOutLambdas_(q0, left_site, RIGHT, trunc_para.inv_tol);
   Gamma(left_site) = TenT();
@@ -437,7 +464,7 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
   assert(physical_index == Gamma(left_site).GetIndex(4));
   assert(physical_index == Gamma(right_down_site).GetIndex(4));
 #endif
-  return {norm, trunc_err1 + trunc_err2, std::max(D1, D2)};
+  return {norm, std::max(actual_trunc_err1, actual_trunc_err2), std::max(actual_D1, actual_D2), e_loc};
 }
 
 /**
@@ -457,10 +484,12 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
  * @return
  */
 template<typename TenElemT, typename QNT>
-typename SquareLatticePEPS<TenElemT, QNT>::RealT SquareLatticePEPS<TenElemT, QNT>::LowerLeftTriangleProject(const QLTensor<TenElemT, QNT> &gate_ten,
-                                                                  const qlpeps::SiteIdx &upper_left_site,
-                                                                  const qlpeps::SimpleUpdateTruncatePara &trunc_para) {
+ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT, QNT>::LowerLeftTriangleProject(const TenT &gate_ten,
+                                                                  const SiteIdx &upper_left_site,
+                                                                  const SimpleUpdateTruncatePara &trunc_para,
+                                                                  const TenT &ham) {
   RealT norm = 1;
+  std::optional<TenElemT> e_loc;
   size_t row = upper_left_site[0], col = upper_left_site[1];
   size_t lower_row = (row + 1) % lambda_vert.rows();
   size_t right_col = (col + 1) % lambda_horiz.cols();
@@ -497,14 +526,20 @@ typename SquareLatticePEPS<TenElemT, QNT>::RealT SquareLatticePEPS<TenElemT, QNT
    *        |
    *        2
    */
+
+  norm *= tmp_ten[5].QuasiNormalize();
+  if (!ham.IsDefault()) { //estimate the local energy by local environment
+    const TenT *state = tmp_ten + 5;
+    e_loc = EvaluateThreeSiteEnergy(ham, *state);
+  }
   tmp_ten[5].Transpose({0, 4, 5, 1, 2, 6, 3}); //(0,4) for upper site, (5,1,2) for left-lower site, (6,3) for right site
   TenT u1, vt1, u2, vt2;
   DTenT s1, s2;
-  RealT trunc_err;
-  size_t D;
+  RealT actual_trunc_err1, actual_trunc_err2;
+  size_t actual_D1, actual_D2;
   qlten::SVD(tmp_ten + 5, 5, tmp_ten[5].Div(),
              trunc_para.trunc_err, trunc_para.D_min, trunc_para.D_max,
-             &u1, &s1, &vt1, &trunc_err, &D);
+             &u1, &s1, &vt1, &actual_trunc_err1, &actual_D1);
   lambda_horiz({lower_right_site}) = s1;
   tmp_ten[6] = QTenSplitOutLambdas_(q1, lower_right_site, LEFT, trunc_para.inv_tol);
   /**
@@ -520,7 +555,7 @@ typename SquareLatticePEPS<TenElemT, QNT>::RealT SquareLatticePEPS<TenElemT, QNT
 
   Contract(&u1, {5}, &s1, {0}, &tmp_ten[7]);
   qlten::SVD(tmp_ten + 7, 2, qn0_, trunc_para.trunc_err, trunc_para.D_min, trunc_para.D_max,
-             &u2, &s2, &vt2, &trunc_err, &D);
+             &u2, &s2, &vt2, &actual_trunc_err2, &actual_D2);
   /**
    *       0
    *       |
@@ -531,7 +566,7 @@ typename SquareLatticePEPS<TenElemT, QNT>::RealT SquareLatticePEPS<TenElemT, QNT
 #ifndef NDEBUG
   assert(vt2.GetIndex(1) == index_2.back());
 #endif
-  norm *= s2.QuasiNormalize();
+  //norm *= s2.QuasiNormalize();
   lambda_vert({lower_left_site}) = s2;
   tmp_ten[8] = QTenSplitOutLambdas_(q0, upper_left_site, DOWN, trunc_para.inv_tol);
 /*
@@ -561,7 +596,7 @@ typename SquareLatticePEPS<TenElemT, QNT>::RealT SquareLatticePEPS<TenElemT, QNT
   assert(index_2.back() == index_2p.back());
   assert(index_3.back() == index_3p.back());
 #endif
-  return norm;
+  return {norm, std::max(actual_trunc_err1, actual_trunc_err2), std::max(actual_D1, actual_D2), e_loc};
 }
 
 }//qlpeps

--- a/include/qlpeps/two_dim_tn/peps/square_lattice_peps_projection_impl.h
+++ b/include/qlpeps/two_dim_tn/peps/square_lattice_peps_projection_impl.h
@@ -263,6 +263,114 @@ typename SquareLatticePEPS<TenElemT, QNT>::RealT SquareLatticePEPS<TenElemT, QNT
  *
  *      |             |
  *      |             |
+ * -----A-------------B--------
+ *      |             |
+ *      |             |
+ *      |             |
+ * -------------------C--------
+ *      |             |
+ *      |             |
+ *
+ *
+ * @tparam TenElemT
+ * @tparam QNT
+ * @param gate_ten  order of the indexes: left_site; right_upper_site; lower_site.
+ * @param upper_site
+ * @param trunc_para
+ * @return
+ */
+template<typename TenElemT, typename QNT>
+ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
+                                          QNT>::UpperRightTriangleProject(const SquareLatticePEPS::TenT &gate_ten,
+                                                                         const SiteIdx &right_upper_site,
+                                                                         const SimpleUpdateTruncatePara &trunc_para,
+                                                                         const TenT &ham) {
+#ifndef NDEBUG
+  auto physical_index = Gamma(right_upper_site).GetIndex(4);
+#endif
+  RealT norm = 1;
+  std::optional<TenElemT> e_loc;
+  size_t row = right_upper_site[0], col = right_upper_site[1];
+  size_t left_col = (col - 1 + lambda_horiz.cols()) % lambda_horiz.cols();
+  size_t lower_row = (row + 1) % lambda_vert.rows();
+  SiteIdx left_site = {row, left_col};
+  SiteIdx lower_site = {lower_row, col};
+  TenT tmp_ten[11], q0, r0, q1, r1;
+  tmp_ten[0] = Eat3SurroundLambdas_(lower_site, UP);
+  QR(tmp_ten, 3, tmp_ten[0].Div(), &q0, &r0);
+  tmp_ten[1] = Eat3SurroundLambdas_(left_site, RIGHT);
+  QR(tmp_ten + 1, 3, tmp_ten[1].Div(), &q1, &r1);
+  tmp_ten[2] = EatSurroundLambdas_(right_upper_site);
+  Contract<TenElemT, QNT, true, false>(r1, tmp_ten[2], 2, 1, 1, tmp_ten[3]);
+  Contract<TenElemT, QNT, false, false>(tmp_ten[3], r0, 2, 2, 1, tmp_ten[4]);
+  Contract(tmp_ten + 4, {4, 2, 6}, &gate_ten, {0, 1, 2}, tmp_ten + 5);
+  /**
+   *  tmp_ten[5] is a rank-7 tensor
+   *         1
+   *         |
+   *  2--tmp_ten[5]--0, physical index = 4,5,6, with order left_site->right_upper_site->lower_site.
+   *        |
+   *        3
+   */
+
+  norm *= tmp_ten[5].QuasiNormalize();
+  if (!ham.IsDefault()) { //estimate the local energy by local environment
+    const TenT *state = tmp_ten + 5;
+    e_loc = EvaluateThreeSiteEnergy(ham, *state);
+  }
+  tmp_ten[5].Transpose({6, 3, 0, 1, 5, 4, 2});
+  TenT u1, vt1, u2, vt2;
+  DTenT s1, s2;
+  RealT actual_trunc_err1, actual_trunc_err2;
+  size_t actual_D1, actual_D2;
+  qlten::SVD(tmp_ten + 5, 5, tmp_ten[5].Div(),
+             trunc_para.trunc_err, trunc_para.D_min, trunc_para.D_max,
+             &u1, &s1, &vt1, &actual_trunc_err1, &actual_D1);
+  //norm *= s1.QuasiNormalize();
+  lambda_horiz({right_upper_site}) = s1;
+  lambda_horiz({right_upper_site}).Transpose({1, 0});
+  tmp_ten[6] = QTenSplitOutLambdas_(q1, left_site, RIGHT, trunc_para.trunc_err);
+  Gamma(left_site) = TenT();
+  Contract<TenElemT, QNT, false, false>(tmp_ten[6], vt1, 0, 2, 1, Gamma(left_site));
+  Gamma(left_site).Transpose({1, 2, 3, 0, 4});
+  Contract(&u1, {5}, &s1, {0}, &tmp_ten[7]);
+  qlten::SVD(tmp_ten + 7, 2, qn0_, trunc_para.trunc_err, trunc_para.D_min, trunc_para.D_max,
+             &u2, &s2, &vt2, &actual_trunc_err2, &actual_D2);
+  /**
+   *       1
+   *       |
+   *  3---vt2--0, physical index = 2
+   *       |
+   *       4
+   */
+  //norm *= s2.QuasiNormalize();
+  lambda_vert({lower_site}) = s2;
+  lambda_vert({lower_site}).Transpose({1, 0});
+  tmp_ten[8] = QTenSplitOutLambdas_(q0, lower_site, UP, trunc_para.trunc_err);
+  Gamma(lower_site) = TenT();
+  Contract<TenElemT, QNT, false, false>(tmp_ten[8], u2, 1, 1, 1, Gamma(lower_site));
+  Gamma(lower_site).Transpose({2, 1, 0, 3, 4});
+  auto inv_lam = DiagMatInv(s1, trunc_para.trunc_err);
+  //Contract(&vt2, {3}, &inv_lam, {0}, &tmp_ten[9]);
+  Contract(&vt2, {4}, &inv_lam, {0}, &tmp_ten[9]);
+  inv_lam = DiagMatInv(lambda_vert({right_upper_site}), trunc_para.trunc_err);
+  Contract<TenElemT, QNT, false, false>(tmp_ten[9], inv_lam, 2, 1, 1, tmp_ten[10]);
+  inv_lam = DiagMatInv(lambda_horiz({row, (col + 1) % lambda_horiz.cols()}), trunc_para.trunc_err);
+  Gamma({right_upper_site}) = TenT();
+  Contract<TenElemT, QNT, false, true>(tmp_ten[10], inv_lam, 3, 0, 1, Gamma({right_upper_site}));
+  Gamma({right_upper_site}).Transpose({2, 3, 4, 0, 1});
+#ifndef NDEBUG
+  assert(physical_index == Gamma(right_upper_site).GetIndex(4));
+  assert(physical_index == Gamma(left_site).GetIndex(4));
+  assert(physical_index == Gamma(lower_site).GetIndex(4));
+#endif
+  return {norm, std::max(actual_trunc_err1, actual_trunc_err2), std::max(actual_D1, actual_D2), e_loc};
+}
+
+/**
+ *
+ *      |             |
+ *      |             |
  * -----B-------------A--------
  *      |             |
  *      |             |
@@ -283,11 +391,13 @@ template<typename TenElemT, typename QNT>
 ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
                                           QNT>::UpperLeftTriangleProject(const SquareLatticePEPS::TenT &gate_ten,
                                                                          const SiteIdx &left_upper_site,
-                                                                         const SimpleUpdateTruncatePara &trunc_para) {
+                                                                         const SimpleUpdateTruncatePara &trunc_para,
+                                                                         const TenT &ham) {
 #ifndef NDEBUG
   auto physical_index = Gamma(left_upper_site).GetIndex(4);
 #endif
   RealT norm = 1;
+  std::optional<TenElemT> e_loc;
   size_t row = left_upper_site[0], col = left_upper_site[1];
   size_t right_col = (col + 1) % lambda_horiz.cols();
   size_t lower_row = (row + 1) % lambda_vert.rows();
@@ -311,15 +421,20 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
    *        3
    */
 
+  norm *= tmp_ten[5].QuasiNormalize();
+  if (!ham.IsDefault()) { //estimate the local energy by local environment
+    const TenT *state = tmp_ten + 5;
+    e_loc = EvaluateThreeSiteEnergy(ham, *state);
+  }
   tmp_ten[5].Transpose({0, 4, 5, 1, 2, 6, 3});
   TenT u1, vt1, u2, vt2;
   DTenT s1, s2;
-  RealT trunc_err1, trunc_err2;
-  size_t D1, D2;
+  RealT actual_trunc_err1, actual_trunc_err2;
+  size_t actual_D1, actual_D2;
   qlten::SVD(tmp_ten + 5, 5, tmp_ten[5].Div(),
              trunc_para.trunc_err, trunc_para.D_min, trunc_para.D_max,
-             &u1, &s1, &vt1, &trunc_err1, &D1);
-  norm *= s1.QuasiNormalize();
+             &u1, &s1, &vt1, &actual_trunc_err1, &actual_D1);
+  //norm *= s1.QuasiNormalize();
   lambda_vert({lower_site}) = s1;
   tmp_ten[6] = QTenSplitOutLambdas_(q1, lower_site, UP, trunc_para.inv_tol);
 
@@ -328,7 +443,7 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
   Gamma(lower_site).Transpose({4, 3, 2, 0, 1});
   Contract(&u1, {5}, &s1, {0}, &tmp_ten[7]);
   qlten::SVD(tmp_ten + 7, 2, qn0_, trunc_para.trunc_err, trunc_para.D_min, trunc_para.D_max,
-             &u2, &s2, &vt2, &trunc_err2, &D2);
+             &u2, &s2, &vt2, &actual_trunc_err2, &actual_D2);
 
   /**
  *       2
@@ -337,7 +452,7 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
  *      |
  *      4
  */
-  norm *= s2.QuasiNormalize();
+  //norm *= s2.QuasiNormalize();
   lambda_horiz({right_site}) = s2;
   lambda_horiz({right_site}).Transpose({1, 0});
   tmp_ten[8] = QTenSplitOutLambdas_(q0, right_site, LEFT, trunc_para.inv_tol);
@@ -358,7 +473,7 @@ ProjectionRes<TenElemT> SquareLatticePEPS<TenElemT,
   assert(physical_index == Gamma(right_site).GetIndex(4));
   assert(physical_index == Gamma(lower_site).GetIndex(4));
 #endif
-  return {norm, trunc_err1 + trunc_err2, std::max(D1, D2)};
+  return {norm, std::max(actual_trunc_err1, actual_trunc_err2), std::max(actual_D1, actual_D2), e_loc};
 }
 
 /**


### PR DESCRIPTION
1.Adding UpperLeftTriangleProject and modify SquareLatticeNNNSimpleUpdate to do projection with UpperRightTriangleProject, UpperLeftTriangleProject, LowerRightTriangleProject and LowerLeftTriangleProject.
2. Modify square_lattice_nnn_simple_update.h to add ConstructTriHamiltonian to obtain ham which can be used to evaluate local energy in simple sweep. The arguments of ConstructTriHamiltonian are only the site index of site B and TriProjPOSITION triposition to distinguish four TriangleProject. The calculation of onsite interaction is also added. Add the calculation and output of Estimated En and TruncErr.  And also consider the setting of PBC.
3. Add EvaluateThreeSiteEnergy in square_lattice_peps_projection_impl.h and use it in four TriangleProject to calculate the local energy of three sites.
4. Change to do QuasiNormalize only once before evaluating the local energy in four TriangleProject.
5. Add a new argument ham_ten in four TriangleProject whose default value is TenT().
6. Change the return type of LowerLeftTriangleProject from double to ProjectionRes.
7. Add SquareNNNHeisenbergWithAMFPinningFieldOBC and SquareNNNHeisenbergWithAMFPinningFieldPBC in test_boson_simple_update.cpp