### PR TITLE
Modify spin_onehalf_triangle_heisenbergJ1J2_sqrpeps.h and corresponding tests

### DIFF
--- a/include/qlpeps/algorithm/vmc_update/model_solvers/spin_onehalf_triangle_heisenbergJ1J2_sqrpeps.h
+++ b/include/qlpeps/algorithm/vmc_update/model_solvers/spin_onehalf_triangle_heisenbergJ1J2_sqrpeps.h
@@ -166,12 +166,12 @@ class SpinOneHalfTriJ1J2HeisenbergSqrPEPS : public ModelEnergySolver<SpinOneHalf
       }
 
       if (row + 1 < ly) {
-        // Triangular J1 diagonal (↘)
+        // Triangular J1 diagonal (↘) + J2 contribution on the same row window (left-up to right-down)
+        // + J2 contribution (↘ with sqrt(5) separation)
         contractor.InitBTen2(tn, LEFT, row);
         contractor.GrowFullBTen2(tn, RIGHT, row, 2, true);
-        auto psi2 = contractor.Trace(tn, {row, 0}, HORIZONTAL);
-        auto inv_psi2 = TenElemT(1.0) / psi2;
         for (size_t col = 0; col + 1 < lx; ++col) {
+          //Calculate diagonal J1 energy contribution
           const SiteIdx ld{row + 1, col};
           const SiteIdx ru{row, col + 1};
           TenElemT eb;
@@ -181,27 +181,39 @@ class SpinOneHalfTriJ1J2HeisenbergSqrPEPS : public ModelEnergySolver<SpinOneHalf
             TenElemT psi_ex = contractor.ReplaceNNNSiteTrace(tn, {row, col}, LEFTDOWN_TO_RIGHTUP, HORIZONTAL,
                                                      (*split_index_tps)(ld)[config(ru)],
                                                      (*split_index_tps)(ru)[config(ld)]);
-            eb = (-0.25 + ComplexConjugate(psi_ex * inv_psi2) * 0.5);
+            eb = (-0.25 + ComplexConjugate(psi_ex * inv_psi) * 0.5);
           }
           if (e_ur.size() != 0) {
             e_ur(row, col) = eb;
           }
           energy_total += eb;
-          if (col + 2 < lx) contractor.ShiftBTen2Window(tn, RIGHT, row);
-        }
 
-        // J2 contribution on the same row window (left-up to right-down)
-        for (size_t col = 0; col + 1 < lx; ++col) {
-          SiteIdx s1{row, col};
-          SiteIdx s2{row + 1, col + 1};
+          //Calculate J2 contribution on the same row window (left-up to right-down)
+          SiteIdx s1{row, col}; //left-top
+          SiteIdx s2{row + 1, col + 1}; //right-bottom
           if (config(s1) == config(s2)) {
             energy_j2_total += TenElemT(0.25);
           } else {
             TenElemT psi_ex = contractor.ReplaceNNNSiteTrace(tn, {row, col}, LEFTUP_TO_RIGHTDOWN, HORIZONTAL,
                                                      (*split_index_tps)(s1)[config(s2)],
                                                      (*split_index_tps)(s2)[config(s1)]);
-            energy_j2_total += (-0.25 + ComplexConjugate(psi_ex * inv_psi2) * 0.5);
+            energy_j2_total += (-0.25 + ComplexConjugate(psi_ex * inv_psi) * 0.5);
           }
+
+          //Calculate J2 contribution (↘ with sqrt(5) separation)
+          if (col + 2 < lx) {
+            s1 = {row + 1, col}; //left-bottom
+            s2 = {row, col + 2}; //right-top
+            if (config(s1) == config(s2)) {
+              energy_j2_total += TenElemT(0.25);
+            } else {
+              TenElemT psi_ex = contractor.ReplaceSqrt5DistTwoSiteTrace(tn, {row, col}, LEFTDOWN_TO_RIGHTUP, HORIZONTAL,
+                                                      (*split_index_tps)(s1)[config(s2)],
+                                                      (*split_index_tps)(s2)[config(s1)]);
+              energy_j2_total += (-0.25 + ComplexConjugate(psi_ex * inv_psi) * 0.5);
+            }
+          }
+          if (col + 2 < lx) contractor.ShiftBTen2Window(tn, RIGHT, row);
         }
         contractor.ShiftBMPSWindow(tn, DOWN);
       }

--- a/tests/integration_tests/integration_test_framework.h
+++ b/tests/integration_tests/integration_test_framework.h
@@ -104,7 +104,10 @@ protected:
     MPI_Barrier(comm);
     
     SplitIndexTPST tps(Ly, Lx);
-    tps.Load(tps_path);
+    if (rank == hp_numeric::kMPIMasterRank) {
+      ASSERT_TRUE(tps.Load(tps_path));
+    }
+    qlpeps::MPI_Bcast(tps, comm);
 
 	    auto executor = new VMCPEPSOptimizer<TenElemT, QNT, MCUpdaterT, ModelT>(
 	        *optimize_para, tps, comm, model);
@@ -129,8 +132,13 @@ protected:
   // Common Monte Carlo measurement workflow
   template<typename ModelT, typename MCUpdaterT>
   void RunMCMeasurement(const ModelT& model) {
+    MPI_Barrier(comm);
+
     SplitIndexTPST tps(Ly, Lx);
-    tps.Load(tps_path);
+    if (rank == hp_numeric::kMPIMasterRank) {
+      ASSERT_TRUE(tps.Load(tps_path));
+    }
+    qlpeps::MPI_Bcast(tps, comm);
 
     auto measure_exe = new MCPEPSMeasurer<TenElemT, QNT, MCUpdaterT, ModelT>(
         tps, *measure_para, comm, model);
@@ -145,7 +153,7 @@ protected:
     double Gflops = (end_flop - start_flop) * 1.e-9 / elapsed_time;
     std::cout << "Measurement Gflops = " << Gflops / elapsed_time << std::endl;
 
-    if (EnableFrameworkEnergyCheck()) {
+    if (EnableFrameworkEnergyCheck() && rank == hp_numeric::kMPIMasterRank) {
       auto [energy, en_err] = measure_exe->OutputEnergy();
       (void)en_err;
       EXPECT_NEAR(std::real(energy), energy_ed, FrameworkEnergyTolerance());
@@ -163,7 +171,11 @@ protected:
     optimize_para->optimizer_params.base_params.learning_rate = 0.0;
     
     SplitIndexTPST tps(Ly, Lx);
-    tps.Load(tps_path);
+    if (rank == hp_numeric::kMPIMasterRank) {
+      ASSERT_TRUE(tps.Load(tps_path));
+    }
+    qlpeps::MPI_Bcast(tps, comm);
+
     auto init_tps = tps;
     
     auto executor = new VMCPEPSOptimizer<TenElemT, QNT, MCUpdaterT, ModelT>(

--- a/tests/integration_tests/test_triangle_heisenberg.cpp
+++ b/tests/integration_tests/test_triangle_heisenberg.cpp
@@ -93,7 +93,7 @@ protected:
   
   void SetUpParameters() override {
     model_name = "triangle_heisenberg";
-    energy_ed = -8.0; // Approximate expected energy for triangle lattice
+    energy_ed = -5.6726617339; // Approximate expected energy for triangle lattice
     
     optimize_para.emplace(
         OptimizerFactory::CreateStochasticReconfiguration(40,
@@ -104,7 +104,7 @@ protected:
                          Configuration(Ly, Lx,
                                        OccupancyNum({Lx * Ly / 2, Lx * Ly / 2})),
                          false), // Sz = 0, not warmed up initially
-        PEPSParams(BMPSTruncateParams<qlten::QLTEN_Double>(6, 12, 1e-15,
+        PEPSParams(BMPSTruncateParams<qlten::QLTEN_Double>(Dpeps, 2 * Dpeps, 1e-15,
                                     CompressMPSScheme::SVD_COMPRESS,
                                     std::make_optional<double>(1e-14),
                                     std::make_optional<size_t>(10))));

--- a/tests/integration_tests/test_triangle_j1j2_heisenberg.cpp
+++ b/tests/integration_tests/test_triangle_j1j2_heisenberg.cpp
@@ -95,7 +95,7 @@ class TriangleJ1J2HeisenbergSystem
 
     void SetUpParameters() override {
       model_name = "triangle_j1j2_heisenberg";
-      energy_ed = -8.5; // Approximate expected energy for triangle J1-J2 lattice
+      energy_ed = -5.4837150685; // Approximate expected energy for triangle J1-J2 lattice
 
       optimize_para.emplace(
           OptimizerFactory::CreateStochasticReconfiguration(40,
@@ -106,7 +106,7 @@ class TriangleJ1J2HeisenbergSystem
                            Configuration(Ly, Lx,
                                          OccupancyNum({Lx * Ly / 2, Lx * Ly / 2})),
                            false), // Sz = 0, not warmed up initially
-          PEPSParams(BMPSTruncateParams<qlten::QLTEN_Double>(6, 12, 1e-15,
+          PEPSParams(BMPSTruncateParams<qlten::QLTEN_Double>(Dpeps, 2 * Dpeps, 1e-15,
                                       CompressMPSScheme::SVD_COMPRESS,
                                       std::make_optional<double>(1e-14),
                                       std::make_optional<size_t>(10))));


### PR DESCRIPTION
I. EvaluateObservables in spin_onehalf_triangle_heisenbergJ1J2_sqrpeps.h: 
	1. Move the calculation of the J2 contribution on the same row window into the previous loop over col;
	2. Replaced inv_psi2 with inv_psi;
	3. Added the calculation of the J2 contribution (↘ with sqrt(5) separation).
II. integration_test_framework.h
	1. Load TPS only on the master rank, then broadcast to other ranks in RunVMCOptimization, RunMCMeasurement, and RunZeroUpdateTest;
 	2. Add MPI_Barrier before loading TPS in RunMCMeasurement;
	3. Only compare measurement energy and energy_ed on the master rank in RunMCMeasurement.
III. test_triangle_heisenberg.cpp and test_triangle_j1j2_heisenberg.cpp
	1. Update energy_ed and replaced Dbmps_min and Dbmps_max with Dpeps and 2 * Dpeps.